### PR TITLE
fix: plugin state outliving the engine across stop/start

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Orion
 
-**Auto-complete every Discord Quest in seconds** &mdash; v4.9.7
+**Auto-complete every Discord Quest in seconds** &mdash; v4.9.9
 
-[![Version](https://img.shields.io/badge/v4.9.7-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://github.com/nyxxbit/discord-quest-completer)
+[![Version](https://img.shields.io/badge/v4.9.9-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://github.com/nyxxbit/discord-quest-completer)
 [![Stars](https://img.shields.io/github/stars/nyxxbit/discord-quest-completer?style=for-the-badge&color=faa61a)](https://github.com/nyxxbit/discord-quest-completer/stargazers)
 [![License](https://img.shields.io/badge/MIT-green?style=for-the-badge)](LICENSE)
 
@@ -198,6 +198,9 @@ Contributions are welcome &mdash; bug reports, PRs, and docs. Start with [`CONTR
 ---
 
 ## Changelog
+
+### v4.9.9
+- **Fix: stopping a quest part-way locked it out of every later start** &mdash; the plugin's dashboard registry is module state that outlives the engine, and `stopOrion()` never touched it, so a quest interrupted by `/orion stop` kept an entry reading `RUNNING`. The cycle loop skips quests in that state, so the queue came up empty on every subsequent `/orion start` while `/orion status` still reported the phantom task. In-flight entries are retired to `STOPPED` on shutdown, late progress updates can no longer re-mark a quest as running once the engine is down, and rows from earlier runs are pruned at start instead of at stop so results stay readable after a run. Auditing the rest of the plugin's module state for the same pattern turned up five more, two of which could hang the cycle loop outright: a rate-limited request rescheduled past a shutdown was dropped without settling its promise, so the awaiting task waited forever (the userscript already rejected with `Shutdown` here &mdash; the port had lost that branch); and a stopped `GAME`/`STREAM` task never resolved at all, because the shutdown cleanup cleared the very timers that would have resolved it, leaving the loop parked and the engine's own teardown unreachable. Either hang then desynced the slash command's private `isRunning` flag from the engine, at which point `/orion stop` answered "Not running." while the engine was still up &mdash; it now reads the engine directly. Also fixed in both engines: two overlapping `STREAM` tasks stashed each other's spoofed `getStreamerActiveStreamMetadata` and one of them restored a fake permanently, so the original is captured once and the spoof refcounted.
 
 ### v4.9.7
 - **The repo installs as a Vencord userplugin now** &mdash; paste `https://github.com/nyxxbit/discord-quest-completer` into nin0's `UserpluginInstaller` and it clones, builds and self-updates from there, no manual clone or file copying ([#42](https://github.com/nyxxbit/discord-quest-completer/issues/42)). That installer does a plain `git clone` into `src/userplugins`, and Vencord's build only reads `index.ts(x)` and `native.ts` from the top level of a plugin folder, so the plugin sources had to move out of `vencord-plugin/` and up to the repo root; a subdirectory layout cannot work with either. `vencord-plugin/README.md` moved to [`docs/VENCORD-PLUGIN.md`](docs/VENCORD-PLUGIN.md). The userscript keeps its path and its raw URL and is not part of the plugin build &mdash; both esbuild and the installer resolve `index.tsx` ahead of `index.js`. A CI job now clones Vencord, checks this repo out the way the installer would, builds, and asserts the plugin reached the renderer and main-process bundles with the slash command registered and no userscript leakage; it builds against Vencord's default branch weekly, so an upstream change that breaks the plugin shows up there instead of in a bug report. The quest engine itself is unchanged this release.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes how Orion is structured internally. It is intended for contributors and the curious, not as a user guide. Last reviewed against `index.js` **v4.9.7**.
+This document describes how Orion is structured internally. It is intended for contributors and the curious, not as a user guide. Last reviewed against `index.js` **v4.9.9**.
 
 ## High-level overview
 

--- a/docs/VENCORD-PLUGIN.md
+++ b/docs/VENCORD-PLUGIN.md
@@ -10,7 +10,7 @@ A [Vencord](https://vencord.dev) userplugin port of [Orion](../README.md), the a
 
 ## Status
 
-**Functional, in sync with userscript v4.9.7.** Quest enrollment, all five task handlers (`VIDEO` / `GAME` / `STREAM` / `ACTIVITY` / `ACHIEVEMENT`), traffic queue with backoff, RunStore patching, and auto-claim are ported. A `/orion` slash command provides start / stop / status from any Discord channel.
+**Functional, in sync with userscript v4.9.9.** Quest enrollment, all five task handlers (`VIDEO` / `GAME` / `STREAM` / `ACTIVITY` / `ACHIEVEMENT`), traffic queue with backoff, RunStore patching, and auto-claim are ported. A `/orion` slash command provides start / stop / status from any Discord channel.
 
 **ACHIEVEMENT auto-bypass — confirmed working.** The userscript can run the OAuth2 authorize flow but Discord's renderer CSP blocks the final POST to `*.discordsays.com`. This plugin includes a native module (`native.ts`) that runs those POSTs in the Electron main process, where CSP doesn't apply &mdash; verified against a live `ACHIEVEMENT_IN_ACTIVITY` quest after the user passed age verification. Quests that are still age-gated (HTTP 403 code 50165 from `/proxy-tickets`) still skip; everything else now completes without launching the activity manually.
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
     const CONFIG = {
         NAME: "Orion",
-        VERSION: "v4.9.7",
+        VERSION: "v4.9.9",
         THEME: "#5865F2",             // discord blurple
         SUCCESS: "#3BA55C",
         WARN: "#faa61a",

--- a/index.js
+++ b/index.js
@@ -1051,6 +1051,8 @@
 
     const Tasks = {
         skipped: new Set(),  // quest IDs that returned 4xx — no point retrying
+        _streamReal: undefined,  // untouched StreamStore method, captured before the first spoof
+        _streamSpoofs: 0,        // active STREAM tasks holding the spoof
 
         // userStatus.progress is a plain object over REST, but dispatched payloads go through
         // the client's own transform first, so the shape isn't ours to assume. Defensive: if
@@ -1250,14 +1252,22 @@
                 let beats = 0;
 
                 if (type === "STREAM") {
-                    const real = Mods.StreamStore?.getStreamerActiveStreamMetadata;
                     if (Mods.StreamStore) {
+                        // Capture the untouched method once and refcount the spoof. Stashing it
+                        // per-task meant a second concurrent STREAM task stashed the first task's
+                        // spoof and later "restored" that, leaving the store patched for good.
+                        if (Tasks._streamSpoofs === 0) Tasks._streamReal = Mods.StreamStore.getStreamerActiveStreamMetadata;
+                        Tasks._streamSpoofs++;
                         Mods.StreamStore.getStreamerActiveStreamMetadata = () => ({ id: gameData.id, pid, sourceName: gameData.name });
                     }
                     // restore unconditionally when the store exists — assigning back an
-                    // undefined `real` is the correct revert. Guarding on `real` being truthy
+                    // undefined original is the correct revert. Guarding on it being truthy
                     // would leave our fake installed when the method was undefined at patch time.
-                    cleanupHook = () => { if (Mods.StreamStore) Mods.StreamStore.getStreamerActiveStreamMetadata = real; };
+                    cleanupHook = () => {
+                        if (Mods.StreamStore && Tasks._streamSpoofs > 0 && --Tasks._streamSpoofs === 0) {
+                            Mods.StreamStore.getStreamerActiveStreamMetadata = Tasks._streamReal;
+                        }
+                    };
                 } else {
                     Patcher.add(game);
                     cleanupHook = () => Patcher.remove(game);
@@ -1279,8 +1289,14 @@
                     try { Mods.Dispatcher?.unsubscribe(CONST.EVT.HEARTBEAT, check); } catch (e) {
                         Logger.log(`[Dispatcher] Unsubscribe failed: ${e.message}`, 'debug');
                     }
-                    RUNTIME.cleanups.delete(finish);
+                    RUNTIME.cleanups.delete(abort);
                 };
+
+                // What shutdown runs. finish() alone clears the timers that would otherwise have
+                // resolved this promise, so registering it bare left the task pending forever.
+                // Separate from finish() so the completion path can still await onComplete
+                // (auto-claim) before resolving.
+                const abort = () => { finish(); resolve(); };
 
                 safetyTimer = setTimeout(() => {
                     if (RUNTIME.running) Tasks.failTask(q, t, 'Timeout exceeded (25m)');
@@ -1332,7 +1348,7 @@
                 };
 
                 Mods.Dispatcher?.subscribe(CONST.EVT.HEARTBEAT, check);
-                RUNTIME.cleanups.add(finish);
+                RUNTIME.cleanups.add(abort);
             });
         },
 

--- a/index.tsx
+++ b/index.tsx
@@ -10,35 +10,35 @@
 import { ApplicationCommandInputType, ApplicationCommandOptionType, sendBotMessage } from "@api/Commands";
 import definePlugin from "@utils/types";
 
-import { readDashboard, startOrion, stopOrion } from "./orion";
+import { isEngineRunning, readDashboard, startOrion, stopOrion } from "./orion";
 import { settings } from "./settings";
 
-let isRunning = false;
-
+// No local `isRunning` mirror: a second flag can disagree with the engine, and when it did,
+// /orion stop refused to stop an engine that was still up. startOrion() sets the engine flag
+// synchronously before its first await, so this reads true immediately after the call below.
 async function ensureStart(): Promise<string> {
-    if (isRunning) return "Already running.";
-    isRunning = true;
-    // fire and forget — main loop awaits internally; lifecycle handled by stopOrion()
-    startOrion().finally(() => { isRunning = false; });
+    if (isEngineRunning()) return "Already running.";
+    // fire and forget — main loop awaits internally; teardown handled by startOrion's finally
+    startOrion();
     return "Started.";
 }
 
 function ensureStop(): string {
-    if (!isRunning) return "Not running.";
+    if (!isEngineRunning()) return "Not running.";
     stopOrion();
-    isRunning = false;
     return "Stopped.";
 }
 
 function statusSummary(): string {
+    const running = isEngineRunning();
     const entries = readDashboard();
-    if (!isRunning && entries.length === 0) return "Idle. Use `/orion start` to begin.";
-    if (entries.length === 0) return isRunning ? "Running. No active tasks yet." : "Idle.";
+    if (!running && entries.length === 0) return "Idle. Use `/orion start` to begin.";
+    if (entries.length === 0) return running ? "Running. No active tasks yet." : "Idle.";
     const lines = entries.map(e => {
         const pct = e.max > 0 ? Math.min(100, (e.cur / e.max) * 100).toFixed(0) : "?";
         return `• ${e.name}: ${e.status} (${pct}%)`;
     });
-    return [`${isRunning ? "Running" : "Stopped"}, ${entries.length} task(s):`, ...lines].join("\n");
+    return [`${running ? "Running" : "Stopped"}, ${entries.length} task(s):`, ...lines].join("\n");
 }
 
 export default definePlugin({

--- a/orion.ts
+++ b/orion.ts
@@ -15,7 +15,7 @@ import { FluxDispatcher, RestAPI } from "@webpack/common";
 import { Patcher } from "./patcher";
 import { settings } from "./settings";
 import { TaskRunner } from "./tasks";
-import { Traffic } from "./traffic";
+import { isSkippableQuest, Traffic } from "./traffic";
 import type { OrionRuntime, Quest, Stores, TaskInfo, TaskType } from "./types";
 import { rnd, sleep } from "./util";
 
@@ -93,12 +93,22 @@ export function subscribeDashboard(fn: () => void): () => void {
 export function readDashboard(): DashboardEntry[] {
     return Array.from(dashboard.values());
 }
+/** Single source of truth for "is the engine up" — index.tsx used to keep its own flag. */
+export function isEngineRunning(): boolean {
+    return RUNTIME.running;
+}
 function emitDashboard(): void {
     for (const fn of dashboardListeners) {
         try { fn(); } catch (e: any) { logger.debug(`[UI] listener threw: ${e?.message}`); }
     }
 }
 function setEntry(id: string, partial: Partial<DashboardEntry> & { name: string; type: TaskType; cur: number; max: number; status: string; }): void {
+    // A stopped engine must never leave an in-flight status behind: mainLoop skips quests
+    // whose entry reads RUNNING, so a late poll landing after shutdown would lock that
+    // quest out of every future start. Terminal updates (COMPLETED/CLAIMED/FAILED) still
+    // get through — those are results worth keeping.
+    if (!RUNTIME.running && (partial.status === "RUNNING" || partial.status === "QUEUE")) return;
+
     const prev = dashboard.get(id) ?? { id, claimable: false, actionRequired: null } as DashboardEntry;
     dashboard.set(id, { ...prev, id, ...partial });
     emitDashboard();
@@ -257,7 +267,8 @@ async function mainLoop(): Promise<void> {
                                 await traffic!.enqueue(`/quests/${q.id}/enroll`, { location: 11, is_targeted: false });
                                 await sleep(rnd(800, 1500));
                             } catch (e: any) {
-                                if (e?.status === 404 || e?.status === 403 || e?.status === 410) {
+                                // one definition of "this quest is gone" — traffic.ts owns it
+                                if (isSkippableQuest(e)) {
                                     RUNTIME.skipped.add(q.id);
                                     tasks!.skipped.add(q.id);
                                     logger.warn(`[Enroll] ${t.name} unavailable (${e.status}). Skipping.`);
@@ -310,6 +321,13 @@ export async function startOrion(): Promise<void> {
     }
     RUNTIME.running = true;
 
+    // Drop finished/aborted rows from earlier runs. Pruned here rather than on stop so results
+    // stay readable after a run ends, but a fresh start never reports a previous session's tasks.
+    for (const [id, e] of dashboard) {
+        if (e.status !== "RUNNING" && e.status !== "QUEUE") dashboard.delete(id);
+    }
+    emitDashboard();
+
     logger.info("Starting OrionQuests");
 
     try {
@@ -347,6 +365,14 @@ export function stopOrion(): void {
         catch (e: any) { failed++; logger.error("Cleanup function threw:", e); }
     }
     RUNTIME.cleanups.clear();
+
+    // Retire whatever was still in flight. Without this, a quest stopped part-way keeps a
+    // RUNNING entry in the registry, mainLoop's "already running" guard skips it on every
+    // later start, and the queue comes up empty while /orion status still reports it.
+    for (const [id, e] of dashboard) {
+        if (e.status === "RUNNING" || e.status === "QUEUE") dashboard.set(id, { ...e, status: "STOPPED" });
+    }
+    emitDashboard();
 
     try { patcher?.clean(); } catch (e: any) { logger.error("Patcher cleanup threw:", e); }
     patcher = null;

--- a/tasks.ts
+++ b/tasks.ts
@@ -14,9 +14,8 @@ import { Logger } from "@utils/Logger";
 import type { PluginNative } from "@utils/types";
 
 import type { Patcher } from "./patcher";
-import type { Traffic } from "./traffic";
 import { settings } from "./settings";
-import { isSkippableQuest } from "./traffic";
+import type { Traffic } from "./traffic";
 import type { DetectedTask, FakeGame, OrionRuntime, Quest, Stores, TaskInfo, TaskType } from "./types";
 import { rnd, sanitize, sleep } from "./util";
 
@@ -47,6 +46,12 @@ export class TaskRunner {
     private patcher: Patcher;
     private runtime: OrionRuntime;
     private cb: TaskCallbacks;
+    /**
+     * Real getStreamerActiveStreamMetadata, stashed once like Patcher does with RunStore.
+     * May legitimately be undefined on builds that don't expose it — see the restore in generic().
+     */
+    private streamReal: any;
+    private streamSpoofs = 0;
 
     constructor(stores: Stores, traffic: Traffic, patcher: Patcher, runtime: OrionRuntime, cb: TaskCallbacks) {
         this.stores = stores;
@@ -54,6 +59,7 @@ export class TaskRunner {
         this.patcher = patcher;
         this.runtime = runtime;
         this.cb = cb;
+        this.streamReal = stores.StreamStore?.getStreamerActiveStreamMetadata;
     }
 
     /**
@@ -241,15 +247,21 @@ export class TaskRunner {
             let beats = 0;
 
             if (type === "STREAM") {
-                const real = this.stores.StreamStore?.getStreamerActiveStreamMetadata;
+                // Restore from the original captured in the constructor, never from whatever is
+                // installed now: with concurrency > 1 a second STREAM task would otherwise stash
+                // the first task's spoof and "restore" that, leaving the store patched after the
+                // engine stops. Refcounted so the last task out puts the real method back — and
+                // it restores even when the original was undefined, since assigning undefined
+                // back is the correct revert (same reasoning as index.js).
                 if (this.stores.StreamStore) {
+                    this.streamSpoofs++;
                     this.stores.StreamStore.getStreamerActiveStreamMetadata = () => ({
                         id: gameData.id, pid, sourceName: gameData.name,
                     });
                 }
                 cleanupHook = () => {
-                    if (this.stores.StreamStore && real) {
-                        this.stores.StreamStore.getStreamerActiveStreamMetadata = real;
+                    if (this.stores.StreamStore && this.streamSpoofs > 0 && --this.streamSpoofs === 0) {
+                        this.stores.StreamStore.getStreamerActiveStreamMetadata = this.streamReal;
                     }
                 };
             } else {
@@ -271,8 +283,15 @@ export class TaskRunner {
                 clearTimeout(watchdogTimer);
                 try { cleanupHook(); } catch (e: any) { logger.debug(`[Task] Cleanup: ${e?.message}`); }
                 try { this.stores.Dispatcher?.unsubscribe(HEARTBEAT_EVT, check); } catch (e: any) { logger.debug(`[Dispatcher] Unsubscribe failed: ${e?.message}`); }
-                this.runtime.cleanups.delete(finish);
+                this.runtime.cleanups.delete(abort);
             };
+
+            // What shutdown runs. finish() alone tears down the timers that would otherwise have
+            // resolved this promise, so registering it bare left the task pending forever: the
+            // cycle loop stayed parked on Promise.all and startOrion never returned. Kept separate
+            // from finish() so the completion path can still wait for onComplete (auto-claim)
+            // before resolving.
+            const abort = () => { finish(); resolve(); };
 
             safetyTimer = setTimeout(() => {
                 if (this.runtime.running) this.failTask(q, t, "Timeout exceeded (25m)");
@@ -316,7 +335,7 @@ export class TaskRunner {
             };
 
             this.stores.Dispatcher?.subscribe(HEARTBEAT_EVT, check);
-            this.runtime.cleanups.add(finish);
+            this.runtime.cleanups.add(abort);
         });
     }
 

--- a/traffic.ts
+++ b/traffic.ts
@@ -107,6 +107,11 @@ export class Traffic {
                             if (this.isRunning()) {
                                 this.queue.push(req);
                                 this.process();
+                            } else {
+                                // settle on shutdown so an awaiter doesn't hang forever — this
+                                // request is no longer in the queue, so the drain path above
+                                // can't reject it for us (matches index.js)
+                                req.reject(new Error("Shutdown"));
                             }
                         }, delay + retryJitter);
                     }


### PR DESCRIPTION
## Summary

Fixes six bugs in the Vencord plugin caused by module-level state surviving `/orion stop` while the engine's object graph is rebuilt on the next start. Two of them hang the cycle loop; one made `/orion stop` refuse to stop a running engine. Two have userscript equivalents, fixed there too.

## Why

Reported symptom: start a game quest, `/orion stop` before it finishes, `/orion start` again — the cycle spins forever with nothing queued, while `/orion status` still reports the old task as `RUNNING (42%)`.

Root cause: `stopOrion()` clears `stores`, `patcher`, `traffic` and `tasks`, but the `dashboard` map at `orion.ts:81` is module state it never touches. `mainLoop` skips any quest whose entry reads `RUNNING` (`orion.ts:248`), so a quest interrupted mid-run is locked out of every later start in that Discord session. Auditing the rest of the module state for the same pattern turned up five more:

1. **`traffic.ts`** — the non-blocking endpoint-429 retry re-queues via `setTimeout`. If the engine stopped before the timer fired, the request was dropped without settling its promise, so the awaiting task handler hung forever and `mainLoop` stayed parked on `Promise.all`. `index.js` already rejects with `Shutdown` here, comment and all; the port lost that branch.
2. **`tasks.ts`** — `finish()` was registered as the shutdown cleanup, but it clears the very timers that would have resolved the task promise. A stopped GAME/STREAM task therefore stayed pending forever, so `startOrion` never reached its `finally` teardown.
3. **`index.tsx`** — kept its own `isRunning` flag beside `RUNTIME.running`. Once the two disagreed (which either hang above causes), `/orion stop` answered "Not running." while the engine was up, leaving no way to stop it.
4. **`tasks.ts` STREAM** — stashed `getStreamerActiveStreamMetadata` per task. With concurrency > 1 (the slider allows 3) two overlapping STREAM tasks stash each other's spoof, and one of them restores a fake permanently — Discord keeps reporting a stream that doesn't exist until the client restarts.
5. **`orion.ts`** — the dashboard was never pruned, so terminal rows piled up across runs and `/orion status` mixed sessions together.
6. **`tasks.ts`** — imported `isSkippableQuest` and never used it, while `orion.ts` inlined the same three status codes by hand.

## Changes

- `orion.ts` — retire in-flight entries to `STOPPED` on shutdown; `setEntry` refuses `RUNNING`/`QUEUE` updates while stopped (closes the race where a late poll re-locks a quest); prune terminal rows at start rather than at stop, so results stay readable after a run; export `isEngineRunning()`; route the enroll skip through `isSkippableQuest`.
- `traffic.ts` — reject with `Shutdown` when a rescheduled retry finds the engine stopped.
- `tasks.ts` — split `abort()` (finish + resolve) from `finish()` and register that as the cleanup; the completion path still awaits `onComplete` before resolving, so auto-claim is unaffected. STREAM captures the original method once and refcounts the spoof, still restoring an undefined original as the existing comment requires.
- `index.tsx` — reads engine state instead of mirroring it.
- `index.js` — same `abort()` split and the same refcounted STREAM restore, keeping the two engines in sync. Its traffic queue already had the shutdown reject.

## Testing

- [x] Ran `npx eslint@9 index.js` — no errors.
- [x] Ran `node --check index.js` — no syntax errors.
- [ ] Pasted into Discord desktop console and verified the change behaves as expected.
- [x] Confirmed clean shutdown (STOP button clears all state).

Plugin side: cloned Vencord, checked this repo out the way UserpluginInstaller does, `pnpm run testTsc` and `pnpm build` clean, plugin present in `dist/renderer.js`.

Verified live on the reported reproduction: `/orion start` on a game quest, `/orion status`, `/orion stop` mid-progress, `/orion start` again. Before, the second start spun with an empty queue while `/orion status` still reported the stale `RUNNING` row; after, the entry reads `STOPPED` and the quest is picked up again on the next cycle.

The userscript changes (the `abort()` split and the refcounted STREAM restore) are build- and lint-verified but not console-tested — the userscript's STOP ends the run, so neither shortcoming was reachable there in the first place; they are kept in sync deliberately.

## Checklist

- [x] `CONFIG.VERSION` bumped (if user-facing).
- [x] README changelog updated at the top of the list.
- [x] ARCHITECTURE.md updated if structure changed. (No structural change — module responsibilities are unchanged; only the version reference was refreshed.)
- [x] Commit messages follow conventional commit style.
- [x] No debug `console.log` left behind.

Numbered **v4.9.9** on the assumption the hideActivity PR (v4.9.8) merges first. If this one lands first, the number and changelog heading want adjusting — and either way the changelog insertion point conflicts with that PR, since both add a section directly under `## Changelog`. Say the word and I'll renumber or drop the release commit entirely.
