### PR TITLE
fix: userscript lifecycle leaks and transport fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Orion
 
-**Auto-complete every Discord Quest in seconds** &mdash; v4.9.7
+**Auto-complete every Discord Quest in seconds** &mdash; v4.9.10
 
-[![Version](https://img.shields.io/badge/v4.9.7-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://github.com/nyxxbit/discord-quest-completer)
+[![Version](https://img.shields.io/badge/v4.9.10-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://github.com/nyxxbit/discord-quest-completer)
 [![Stars](https://img.shields.io/github/stars/nyxxbit/discord-quest-completer?style=for-the-badge&color=faa61a)](https://github.com/nyxxbit/discord-quest-completer/stargazers)
 [![License](https://img.shields.io/badge/MIT-green?style=for-the-badge)](LICENSE)
 
@@ -198,6 +198,9 @@ Contributions are welcome &mdash; bug reports, PRs, and docs. Start with [`CONTR
 ---
 
 ## Changelog
+
+### v4.9.10
+- **Fix: userscript lifecycle and transport-fallback issues** &mdash; the `>` dashboard hotkey registered a document-level listener that shutdown never detached, so it outlived the dashboard and stacked one more copy on every paste, each closing over a dead overlay. Clicking **STOP** and pasting again within a second was also a dead end: the re-entry guard stayed held for the full grace period, so the new paste was refused with "Already running." while the overlay it had just re-shown was removed a moment later by the old timer, leaving nothing on screen; the guard is released immediately now, and the teardown holds references to its own nodes so it can no longer delete a newer dashboard's stylesheet. The manual **CLAIM REWARD** button could stick at "WAITING..." for the rest of the session when the claim endpoint answered 2xx without `claimed_at` &mdash; neither the success branch nor the catch fired, so the state was never reset. The localhost-relay probe cached its answer for the whole run in both directions, so a relay started mid-run was never picked up and one that died was still used; it now re-probes on a one-minute TTL and drops the cached answer if the relay stops responding mid-POST, letting the next transport take over. The `DiscordNative` fallback no longer speculatively invokes `fileManager.fetchURL` or `processUtils.fetch` &mdash; neither is an HTTP client, and calling privileged IPC with a POST-shaped argument risks side effects the return-shape check cannot detect. Quest ids are now escaped where they reach `innerHTML`, matching the rule already applied to quest and reward names.
 
 ### v4.9.7
 - **The repo installs as a Vencord userplugin now** &mdash; paste `https://github.com/nyxxbit/discord-quest-completer` into nin0's `UserpluginInstaller` and it clones, builds and self-updates from there, no manual clone or file copying ([#42](https://github.com/nyxxbit/discord-quest-completer/issues/42)). That installer does a plain `git clone` into `src/userplugins`, and Vencord's build only reads `index.ts(x)` and `native.ts` from the top level of a plugin folder, so the plugin sources had to move out of `vencord-plugin/` and up to the repo root; a subdirectory layout cannot work with either. `vencord-plugin/README.md` moved to [`docs/VENCORD-PLUGIN.md`](docs/VENCORD-PLUGIN.md). The userscript keeps its path and its raw URL and is not part of the plugin build &mdash; both esbuild and the installer resolve `index.tsx` ahead of `index.js`. A CI job now clones Vencord, checks this repo out the way the installer would, builds, and asserts the plugin reached the renderer and main-process bundles with the slash command registered and no userscript leakage; it builds against Vencord's default branch weekly, so an upstream change that breaks the plugin shows up there instead of in a bug report. The quest engine itself is unchanged this release.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes how Orion is structured internally. It is intended for contributors and the curious, not as a user guide. Last reviewed against `index.js` **v4.9.7**.
+This document describes how Orion is structured internally. It is intended for contributors and the curious, not as a user guide. Last reviewed against `index.js` **v4.9.10**.
 
 ## High-level overview
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
     const CONFIG = {
         NAME: "Orion",
-        VERSION: "v4.9.7",
+        VERSION: "v4.9.10",
         THEME: "#5865F2",             // discord blurple
         SUCCESS: "#3BA55C",
         WARN: "#faa61a",
@@ -199,7 +199,7 @@
     ── ── ── ── ── ── ── ── ── ── ── ── ── ── ── ── ── ── ── ── */
 
     const Logger = {
-        root: null, tasks: new Map(), tickerId: null,
+        root: null, tasks: new Map(), tickerId: null, _hotkey: null,
 
         init() {
             const oldUI = document.getElementById('orion-ui'); if (oldUI) oldUI.remove();
@@ -417,6 +417,12 @@
 
                             this.updateTask(questId, { ...taskData, status: "CLAIMED", claimable: false, claimState: null });
                             setTimeout(() => this.removeTask(questId), 2000);
+                        } else {
+                            // 2xx without claimed_at — the reward isn't claimed, and without this
+                            // branch claimState stayed WAITING forever, so the button was dead for
+                            // the rest of the session with no way back.
+                            this.log(`[Claim] Reward for "${taskData.name}" wasn't confirmed. Claim it from Discord's Quests page.`, 'warn');
+                            this.updateTask(questId, { ...taskData, claimState: 'FAILED' });
                         }
                     } catch (err) {
                         this.log(`[Claim] Action required for "${taskData.name}". Check Discord UI for captcha.`, 'warn');
@@ -428,7 +434,12 @@
 
             document.getElementById('orion-close').onclick = () => this.toggle();
             document.getElementById('orion-stop').onclick = () => this.shutdown();
-            document.addEventListener('keydown', e => (e.key === '>' || (e.shiftKey && e.key === '.')) && this.toggle());
+
+            // Keep the reference so shutdown() can detach it. An anonymous listener here
+            // survived STOP and stacked one more copy per paste, each closing over a dead
+            // dashboard — the same stacking the gear handler below is careful to avoid.
+            this._hotkey = e => (e.key === '>' || (e.shiftKey && e.key === '.')) && this.toggle();
+            document.addEventListener('keydown', this._hotkey);
 
             // gear toggles the picker options panel. Those nodes only exist during the picker
             // phase, so look them up at click time and no-op otherwise. Registered once here
@@ -447,7 +458,10 @@
             this.startTicker();
         },
 
-        toggle() { this.root.style.display = this.root.style.display === 'none' ? 'flex' : 'none'; },
+        toggle() {
+            if (!this.root?.parentElement) return;  // dashboard already torn down
+            this.root.style.display = this.root.style.display === 'none' ? 'flex' : 'none';
+        },
 
         shutdown() {
             if (!RUNTIME.running) return;
@@ -455,6 +469,7 @@
             this.log("[System] Stopping script & cleaning up...", "warn");
 
             if (this.tickerId) clearInterval(this.tickerId);
+            if (this._hotkey) { document.removeEventListener('keydown', this._hotkey); this._hotkey = null; }
 
             for (const cleanupFn of RUNTIME.cleanups) {
                 try { cleanupFn(); } catch (e) { this.log(`[Cleanup] ${e.message}`, 'debug'); }
@@ -462,11 +477,21 @@
             RUNTIME.cleanups.clear();
 
             Patcher.clean();
+
+            // Free the re-entry guard now, not in a second. Holding it for the grace period
+            // meant a paste inside that window was refused with "Already running." — and the
+            // UI that guard had just re-shown was then removed by this very timer, leaving
+            // nothing on screen and no hint that pasting again would work.
+            window.orionLock = false;
+
+            // Capture the nodes to drop instead of looking them up by id when the timer fires:
+            // a new instance reuses the same ids, so a late getElementById('orion-styles')
+            // would delete the *new* dashboard's stylesheet.
+            const styles = document.getElementById('orion-styles');
+            const root = this.root;
             setTimeout(() => {
-                const styles = document.getElementById('orion-styles');
-                if (styles) styles.remove();
-                if (this.root?.parentElement) this.root.remove();
-                window.orionLock = false;
+                if (styles?.parentElement) styles.remove();
+                if (root?.parentElement) root.remove();
             }, 1000);
         },
 
@@ -517,7 +542,8 @@
             if (oldData && oldData.status === newData.status && oldData.removing === newData.removing &&
                 oldData.claimable === newData.claimable && oldData.claimState === newData.claimState &&
                 oldData.actionRequired === newData.actionRequired) {
-                const card = document.getElementById(`orion-task-${id}`);
+                // must match the escaped id render() writes, or the in-place update misses
+                const card = document.getElementById(`orion-task-${esc(id)}`);
                 if (card) {
                     const pct = this._getPct(newData);
 
@@ -602,7 +628,7 @@
                 if (t.claimable) {
                     if (t.claimState === 'WAITING') actionBtn = `<button class="claim-btn" disabled>WAITING...</button>`;
                     else if (t.claimState === 'FAILED') actionBtn = `<button class="claim-btn failed" disabled>ACTION REQUIRED</button>`;
-                    else actionBtn = `<button class="claim-btn" data-id="${id}">CLAIM REWARD</button>`;
+                    else actionBtn = `<button class="claim-btn" data-id="${esc(id)}">CLAIM REWARD</button>`;
                 } else if (t.actionRequired === 'ENROLL') {
                     statusText = 'ACTION REQUIRED'; progressLabel = 'Accept quest in Discord';
                     actionBtn = `<button class="goto-btn">GO TO QUESTS</button>`;
@@ -624,7 +650,7 @@
                 }
 
                 return `
-                <div id="orion-task-${id}" class="task-card ${stateClass} ${removingClass}">
+                <div id="orion-task-${esc(id)}" class="task-card ${stateClass} ${removingClass}">
                     <div class="task-icon" style="--p: ${pct}%">
                         <div class="task-icon-inner">${icon}</div>
                         ${stateClass === 'running' ? `<div class="task-icon-overlay">${Math.floor(pct)}%</div>` : ''}
@@ -1356,12 +1382,18 @@
         // process), DiscordNative HTTP candidates (if any exist), raw fetch.
         _relayUrl: 'http://127.0.0.1:43210',
         _relayProbe: null,
+        _relayProbeAt: 0,
+        RELAY_PROBE_TTL: 60000,   // re-probe after a minute instead of trusting one answer forever
 
         // Cache the in-flight probe promise so concurrent callers (video runs at
         // concurrency 2) all await the same result, instead of a second caller seeing
-        // a half-set flag and getting undefined (falsy) back.
+        // a half-set flag and getting undefined (falsy) back. Cached for a TTL rather than
+        // for the whole run: a permanent cache meant a relay started mid-run was never
+        // picked up, and a relay that died was still treated as available.
         _probeRelay() {
-            return this._relayProbe ??= (async () => {
+            if (this._relayProbe && Date.now() - this._relayProbeAt < this.RELAY_PROBE_TTL) return this._relayProbe;
+            this._relayProbeAt = Date.now();
+            return this._relayProbe = (async () => {
                 try {
                     const r = await Promise.race([
                         fetch(`${this._relayUrl}/health`, { method: 'GET', redirect: 'error' }),
@@ -1380,16 +1412,26 @@
             //    the relay forwards to discordsays.com from outside the browser sandbox.
             //    This is the no-mod path: standalone userscript + tiny helper.
             if (await this._probeRelay()) {
-                const r = await fetch(`${this._relayUrl}/proxy`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ url, headers, body: jsonBody }),
-                    redirect: 'error'
-                });
-                if (!r.ok) throw { status: r.status, body: await r.text() };
-                const result = await r.json();
-                if (!result.ok) throw { status: result.status, body: result.body };
-                return result;
+                let r;
+                try {
+                    r = await fetch(`${this._relayUrl}/proxy`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ url, headers, body: jsonBody }),
+                        redirect: 'error'
+                    });
+                } catch (e) {
+                    // relay went away between probe and POST — drop the cached answer and let
+                    // the next transport try, instead of failing the whole bypass on a dead port
+                    this._relayProbe = null;
+                    Logger.log(`[Bypass] Relay stopped responding, trying other transports: ${e?.message ?? e}`, 'debug');
+                }
+                if (r) {
+                    if (!r.ok) throw { status: r.status, body: await r.text() };
+                    const result = await r.json();
+                    if (!result.ok) throw { status: result.status, body: result.body };
+                    return result;
+                }
             }
 
             // 2) Vencord plugin native module — works if user has OrionQuests Vencord plugin
@@ -1425,10 +1467,13 @@
             //    plausible paths and use the first that's a callable function.
             const dn = window.DiscordNative;
             if (dn) {
+                // Only members that plausibly *are* an HTTP client. fileManager.fetchURL and
+                // processUtils.fetch were in this list, and neither is one: the first retrieves
+                // a URL into the file layer (a write or a save dialog, not a POST) and the second
+                // belongs to process management. Calling privileged IPC speculatively with a
+                // POST-shaped argument risks a side effect the status-shape check can't even see.
                 const probes = [
                     () => dn.http?.makeRequest,
-                    () => dn.fileManager?.fetchURL,
-                    () => dn.processUtils?.fetch,
                     () => dn.app?.makeRequest,
                 ];
                 for (const probe of probes) {


### PR DESCRIPTION
## Summary

Six fixes in `index.js` only, from a review of the userscript-specific paths the plugin port doesn't share: the dashboard's lifecycle, the manual claim flow, and the discordsays transport fallback.

## Why

None of these hang the engine, but four of them strand the user with no way back short of re-pasting, and two are inconsistent with rules the file states about itself.

1. **Hotkey listener leaks and stacks.** The `>` toggle registered a document-level keydown listener that `shutdown()` never detached. It outlived the dashboard, and every subsequent paste added another copy, each closed over a dead overlay. The gear handler immediately below carries a comment explaining it is registered once precisely so "a fresh listener doesn't stack every time it opens", and `docs/ARCHITECTURE.md` states every long-running subscription registers a cleanup in `RUNTIME.cleanups` — this one registered none.
2. **STOP then re-paste inside 1s dead-ends.** `shutdown()` held `window.orionLock` for a 1000ms grace period, so a paste in that window hit the re-entry guard: it re-showed the old overlay, logged "Already running.", and returned — then the pending timer removed that overlay and freed the lock. Net effect: no dashboard, a message that says the opposite of what happened, and no indication that pasting once more would work. The same timer looked `#orion-styles` up by id, so on a fast re-paste it would have deleted the *new* dashboard's stylesheet.
3. **CLAIM REWARD can stick at WAITING.** A 2xx response without `claimed_at` matched neither the success branch nor the catch, so `claimState` stayed `WAITING` and `render()` kept drawing a disabled button for the rest of the session. The auto-claim path handles the same case by falling through to a claimable button.
4. **Relay probe cached for the whole run.** `_probeRelay` memoised its answer permanently in both directions: a relay started mid-run was never picked up, and a relay that died was still trusted, so every later bypass POST hit a dead port and threw a raw fetch error rather than trying the next transport.
5. **Speculative privileged IPC.** The `DiscordNative` fallback called whichever of four undocumented members happened to be a function, with a POST-shaped argument. Two of them are not HTTP clients: `fileManager.fetchURL` pulls a URL into the file layer (a write or a save dialog), `processUtils.fetch` belongs to process management. Because the loop only checks whether the return value carries a status field, an odd result is silently treated as "not it" and any side effect goes unnoticed.
6. **Unescaped quest id in an `innerHTML` sink.** Not exploitable with snowflake ids, but inconsistent with the rule at the top of the file — "Escape server-controlled strings before they touch innerHTML" — which is applied to quest and reward names two lines away.

## Changes

- Hotkey listener kept as `Logger._hotkey` and detached in `shutdown()`; `toggle()` no-ops on a detached root.
- `window.orionLock` released immediately at shutdown; the deferred teardown captures the stylesheet and root nodes instead of resolving them by id when it fires.
- Manual claim resets to the ACTION REQUIRED state on a 2xx without `claimed_at`, with a log pointing at Discord's Quests page.
- Relay probe re-probes on a 60s TTL, and a relay that stops responding mid-POST invalidates the cache and falls through to the next transport.
- `DiscordNative` probe list trimmed to `http.makeRequest` and `app.makeRequest`.
- Quest ids escaped where they reach `innerHTML`; the in-place card lookup escapes identically so the two can't diverge.

## Testing

- [x] Ran `npx eslint@9 index.js` — no errors.
- [x] Ran `node --check index.js` — no syntax errors.
- [x] Pasted into Discord desktop console and verified the change behaves as expected.
- [x] Confirmed clean shutdown (STOP button clears all state).

Exercised by hand on Discord desktop: **STOP followed immediately by a re-paste** now yields a working dashboard, where before it logged "Already running." and then left an empty screen once the pending teardown fired; and the **Shift+. hotkey** still toggles the overlay after the listener was made detachable.

Two things were not reproduced by hand and are reasoned from the code rather than observed, so treat them as such: the hotkey being inert *after* STOP, and the listener accumulation itself — the latter had no visible symptom to begin with, since each leaked listener was bound to its own detached overlay. The claim-button and relay-probe paths need a 2xx-without-`claimed_at` response and a mid-run relay shutdown respectively; neither was staged.

## Checklist

- [x] `CONFIG.VERSION` bumped (if user-facing).
- [x] README changelog updated at the top of the list.
- [x] ARCHITECTURE.md updated if structure changed. (Version reference only — no structural change.)
- [x] Commit messages follow conventional commit style.
- [x] No debug `console.log` left behind. (Verified by grep: this branch adds no `console.*` calls; the existing ones are `Logger.log`'s own output and the fatal handlers.)

`docs/VENCORD-PLUGIN.md`'s "in sync with userscript" version is deliberately not bumped: no plugin sources changed here, and most of these paths — dashboard DOM, relay transport — have no plugin equivalent.

Numbered **v4.9.10** assuming the two other pending PRs (v4.9.8, v4.9.9) merge first. The changelog insertion point conflicts with both, since all three add a section directly under `## Changelog`. Happy to renumber or drop the version bump entirely, whichever suits your release flow.
