### PR TITLE
fix: settings that never took effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Orion
 
-**Auto-complete every Discord Quest in seconds** &mdash; v4.9.7
+**Auto-complete every Discord Quest in seconds** &mdash; v4.9.11
 
-[![Version](https://img.shields.io/badge/v4.9.7-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://github.com/nyxxbit/discord-quest-completer)
+[![Version](https://img.shields.io/badge/v4.9.11-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://github.com/nyxxbit/discord-quest-completer)
 [![Stars](https://img.shields.io/github/stars/nyxxbit/discord-quest-completer?style=for-the-badge&color=faa61a)](https://github.com/nyxxbit/discord-quest-completer/stargazers)
 [![License](https://img.shields.io/badge/MIT-green?style=for-the-badge)](LICENSE)
 
@@ -198,6 +198,12 @@ Contributions are welcome &mdash; bug reports, PRs, and docs. Start with [`CONTR
 ---
 
 ## Changelog
+
+### v4.9.11
+- **Fix (plugin): `Verbose logging` did nothing at all** &mdash; the setting was defined but never read anywhere in the plugin. Vencord's `Logger.debug` always calls `console.debug`, which browsers hide unless the console is switched to Verbose, so every debug line was emitted regardless of the toggle and whether you saw it came down to a DevTools filter. Debug output now goes through one gate: with the setting on it is raised to info level, where it shows by default; with it off nothing changes from before.
+- **Fix (plugin): enabling `Try achievement bypass` mid-run left already-skipped quests skipped** &mdash; when the bypass is off the plugin logs "enable it in settings if you want it" and marks the quest skipped, in the same set used for quests that genuinely cannot be completed. Acting on that message did nothing until a full stop/start, because `activeQuests()` filters that set for the life of the run. A refusal for want of consent is now recorded separately from a real failure, and switching the setting on returns those quests to the queue for the next cycle.
+- **Concurrency sliders now say when they apply** &mdash; both are read when a cycle starts, so a change affects the next batch rather than tasks already running. Behaviour is unchanged; it just wasn't written down anywhere.
+- Adds `hooks.ts`, a dependency-free bridge that lets a settings change reach the running engine. `settings.ts` cannot import `orion.ts` directly &mdash; that closes an import cycle &mdash; and the engine clears its handlers on stop so a hook never outlives the run it belongs to.
 
 ### v4.9.7
 - **The repo installs as a Vencord userplugin now** &mdash; paste `https://github.com/nyxxbit/discord-quest-completer` into nin0's `UserpluginInstaller` and it clones, builds and self-updates from there, no manual clone or file copying ([#42](https://github.com/nyxxbit/discord-quest-completer/issues/42)). That installer does a plain `git clone` into `src/userplugins`, and Vencord's build only reads `index.ts(x)` and `native.ts` from the top level of a plugin folder, so the plugin sources had to move out of `vencord-plugin/` and up to the repo root; a subdirectory layout cannot work with either. `vencord-plugin/README.md` moved to [`docs/VENCORD-PLUGIN.md`](docs/VENCORD-PLUGIN.md). The userscript keeps its path and its raw URL and is not part of the plugin build &mdash; both esbuild and the installer resolve `index.tsx` ahead of `index.js`. A CI job now clones Vencord, checks this repo out the way the installer would, builds, and asserts the plugin reached the renderer and main-process bundles with the slash command registered and no userscript leakage; it builds against Vencord's default branch weekly, so an upstream change that breaks the plugin shows up there instead of in a bug report. The quest engine itself is unchanged this release.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes how Orion is structured internally. It is intended for contributors and the curious, not as a user guide. Last reviewed against `index.js` **v4.9.7**.
+This document describes how Orion is structured internally. It is intended for contributors and the curious, not as a user guide. Last reviewed against `index.js` **v4.9.11**.
 
 ## High-level overview
 
@@ -30,6 +30,7 @@ OrionQuest/
 ├── traffic.ts                     # FIFO request queue with backoff
 ├── patcher.ts                     # RunningGameStore monkey-patch + RPC dispatch
 ├── settings.ts                    # Vencord settings schema
+├── hooks.ts                       # settings-to-engine bridge (imports nothing, breaks the cycle)
 ├── types.ts  ├── util.ts
 │
 ├── docs/

--- a/docs/VENCORD-PLUGIN.md
+++ b/docs/VENCORD-PLUGIN.md
@@ -10,7 +10,7 @@ A [Vencord](https://vencord.dev) userplugin port of [Orion](../README.md), the a
 
 ## Status
 
-**Functional, in sync with userscript v4.9.7.** Quest enrollment, all five task handlers (`VIDEO` / `GAME` / `STREAM` / `ACTIVITY` / `ACHIEVEMENT`), traffic queue with backoff, RunStore patching, and auto-claim are ported. A `/orion` slash command provides start / stop / status from any Discord channel.
+**Functional, in sync with userscript v4.9.11.** Quest enrollment, all five task handlers (`VIDEO` / `GAME` / `STREAM` / `ACTIVITY` / `ACHIEVEMENT`), traffic queue with backoff, RunStore patching, and auto-claim are ported. A `/orion` slash command provides start / stop / status from any Discord channel.
 
 **ACHIEVEMENT auto-bypass — confirmed working.** The userscript can run the OAuth2 authorize flow but Discord's renderer CSP blocks the final POST to `*.discordsays.com`. This plugin includes a native module (`native.ts`) that runs those POSTs in the Electron main process, where CSP doesn't apply &mdash; verified against a live `ACHIEVEMENT_IN_ACTIVITY` quest after the user passed age verification. Quests that are still age-gated (HTTP 403 code 50165 from `/proxy-tickets`) still skip; everything else now completes without launching the activity manually.
 
@@ -96,7 +96,7 @@ Exposed in Vencord's plugin settings UI. Persisted via Vencord's `DataStore`.
 | Hide activity | `false` | `CONFIG.HIDE_ACTIVITY` |
 | Game concurrency | `1` | inferred from `runConcurrent(queues.game, 1)` |
 | Video concurrency | `2` | inferred from `runConcurrent(queues.video, 2)` |
-| Verbose logging | `false` | (debug logs) |
+| Verbose logging | `false` | (debug logs) &mdash; raises Orion's debug messages to info level so they appear without switching the console to Verbose |
 
 ---
 

--- a/hooks.ts
+++ b/hooks.ts
@@ -1,0 +1,29 @@
+/*
+ * OrionQuests — Vencord userplugin
+ * Copyright (c) 2026 nyxxbit
+ * SPDX-License-Identifier: MIT
+ *
+ * Bridge between the settings panel and the running engine.
+ *
+ * Vencord calls a setting's onChange the moment the user flips it, but
+ * settings.ts cannot reach into orion.ts to act on it: orion.ts imports
+ * settings.ts, so the reverse import would close a cycle. This module
+ * imports nothing, so both sides can depend on it.
+ *
+ * The engine registers its handlers at start and clears them at stop. A
+ * hook left pointing at a torn-down engine is the same class of bug as
+ * the module state that used to outlive it.
+ */
+
+type Handler<T> = (value: T) => void;
+
+let onAchievementBypass: Handler<boolean> | null = null;
+
+export function setAchievementBypassHook(fn: Handler<boolean> | null): void {
+    onAchievementBypass = fn;
+}
+
+/** No-op while the engine is down — settings are read fresh at the next start. */
+export function fireAchievementBypassChanged(value: boolean): void {
+    onAchievementBypass?.(value);
+}

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 
     const CONFIG = {
         NAME: "Orion",
-        VERSION: "v4.9.7",
+        VERSION: "v4.9.11",
         THEME: "#5865F2",             // discord blurple
         SUCCESS: "#3BA55C",
         WARN: "#faa61a",

--- a/orion.ts
+++ b/orion.ts
@@ -12,12 +12,13 @@ import { Logger } from "@utils/Logger";
 import { findByProps, findStore } from "@webpack";
 import { FluxDispatcher, RestAPI } from "@webpack/common";
 
+import { setAchievementBypassHook } from "./hooks";
 import { Patcher } from "./patcher";
 import { settings } from "./settings";
 import { TaskRunner } from "./tasks";
 import { Traffic } from "./traffic";
 import type { OrionRuntime, Quest, Stores, TaskInfo, TaskType } from "./types";
-import { rnd, sleep } from "./util";
+import { debug, rnd, sleep } from "./util";
 
 const logger = new Logger("OrionQuests");
 
@@ -95,7 +96,7 @@ export function readDashboard(): DashboardEntry[] {
 }
 function emitDashboard(): void {
     for (const fn of dashboardListeners) {
-        try { fn(); } catch (e: any) { logger.debug(`[UI] listener threw: ${e?.message}`); }
+        try { fn(); } catch (e: any) { debug(logger, `[UI] listener threw: ${e?.message}`); }
     }
 }
 function setEntry(id: string, partial: Partial<DashboardEntry> & { name: string; type: TaskType; cur: number; max: number; status: string; }): void {
@@ -163,7 +164,7 @@ async function onTaskComplete(q: Quest, t: TaskInfo): Promise<void> {
                 tag: `orion-${q.id}`,
             });
         }
-    } catch (e: any) { logger.debug(`[Notification] ${e?.message}`); }
+    } catch (e: any) { debug(logger, `[Notification] ${e?.message}`); }
 
     if (settings.store.tryToClaimReward && tasks) {
         try {
@@ -321,11 +322,19 @@ export async function startOrion(): Promise<void> {
             onComplete: onTaskComplete,
         });
 
+        // Turning the achievement bypass on mid-run should reach the quests it already
+        // refused, not just the ones detected after the flip.
+        setAchievementBypassHook(enabled => {
+            if (!enabled || !tasks) return;
+            const restored = tasks.retryConsentSkipped();
+            if (restored > 0) logger.info(`[Settings] Achievement bypass enabled — retrying ${restored} skipped quest(s) on the next cycle.`);
+        });
+
         try {
             if (typeof Notification !== "undefined" && Notification.permission === "default") {
                 Notification.requestPermission();
             }
-        } catch (e: any) { logger.debug(`[Notification] permission request failed: ${e?.message}`); }
+        } catch (e: any) { debug(logger, `[Notification] permission request failed: ${e?.message}`); }
 
         await mainLoop();
     } catch (e: any) {
@@ -347,6 +356,10 @@ export function stopOrion(): void {
         catch (e: any) { failed++; logger.error("Cleanup function threw:", e); }
     }
     RUNTIME.cleanups.clear();
+
+    // Drop the settings bridge with everything else it points at — a hook holding a
+    // torn-down TaskRunner is the same leak as any other module state outliving the engine.
+    setAchievementBypassHook(null);
 
     try { patcher?.clean(); } catch (e: any) { logger.error("Patcher cleanup threw:", e); }
     patcher = null;

--- a/patcher.ts
+++ b/patcher.ts
@@ -14,6 +14,7 @@
 import { Logger } from "@utils/Logger";
 
 import type { FakeGame, Stores } from "./types";
+import { debug } from "./util";
 
 const logger = new Logger("OrionQuests");
 
@@ -44,7 +45,7 @@ export class Patcher {
             if (typeof stores.RunStore[name] === "function") this.real[name] = stores.RunStore[name];
         }
         const absent = PATCHED_METHODS.filter(n => !this.real[n]);
-        if (absent.length) logger.debug(`[Patcher] Store lacks ${absent.join(", ")} — not patching those.`);
+        if (absent.length) debug(logger, `[Patcher] Store lacks ${absent.join(", ")} — not patching those.`);
     }
 
     private toggle(on: boolean): void {
@@ -106,7 +107,7 @@ export class Patcher {
                 games: this.stores.RunStore.getRunningGames(),
             });
         } catch (e: any) {
-            logger.debug(`[Patcher] dispatch failed: ${e?.message}`);
+            debug(logger, `[Patcher] dispatch failed: ${e?.message}`);
         }
     }
 
@@ -131,7 +132,7 @@ export class Patcher {
                     : null,
             });
         } catch (e: any) {
-            logger.debug(`[Patcher] rpc dispatch failed: ${e?.message}`);
+            debug(logger, `[Patcher] rpc dispatch failed: ${e?.message}`);
         }
     }
 

--- a/settings.ts
+++ b/settings.ts
@@ -10,6 +10,8 @@
 import { definePluginSettings } from "@api/Settings";
 import { OptionType } from "@utils/types";
 
+import { fireAchievementBypassChanged } from "./hooks";
+
 export const settings = definePluginSettings({
     autoStart: {
         type: OptionType.BOOLEAN,
@@ -21,8 +23,9 @@ export const settings = definePluginSettings({
     achievementBypass: {
         type: OptionType.BOOLEAN,
         description:
-            "Auto-complete ACHIEVEMENT_IN_ACTIVITY quests by OAuth-authorizing the quest's app on your account (scopes: identify, applications.commands, applications.entitlements), reporting progress to the activity backend, then revoking the grant right after. This automates your logged-in account and can put the WHOLE account at risk under Discord's quest-automation enforcement. Off by default — turning it on is your explicit consent.",
+            "Auto-complete ACHIEVEMENT_IN_ACTIVITY quests by OAuth-authorizing the quest's app on your account (scopes: identify, applications.commands, applications.entitlements), reporting progress to the activity backend, then revoking the grant right after. This automates your logged-in account and can put the WHOLE account at risk under Discord's quest-automation enforcement. Off by default — turning it on is your explicit consent. Turning it on mid-run puts back any quest that was skipped only because it was off.",
         default: false,
+        onChange: (value: boolean) => fireAchievementBypassChanged(value),
     },
 
     tryToClaimReward: {
@@ -42,7 +45,7 @@ export const settings = definePluginSettings({
     gameConcurrency: {
         type: OptionType.SLIDER,
         description:
-            "Parallel game quests. Values above 1 risk detection — keep at 1 unless you know what you're doing.",
+            "Parallel game quests. Values above 1 risk detection — keep at 1 unless you know what you're doing. Read when a cycle starts, so a change applies to the next batch rather than to tasks already in flight.",
         markers: [1, 2, 3],
         stickToMarkers: true,
         default: 1,
@@ -51,7 +54,7 @@ export const settings = definePluginSettings({
     videoConcurrency: {
         type: OptionType.SLIDER,
         description:
-            "Parallel video quests. Higher values finish faster but make more API calls.",
+            "Parallel video quests. Higher values finish faster but make more API calls. Read when a cycle starts, so a change applies to the next batch rather than to tasks already in flight.",
         markers: [1, 2, 3, 4],
         stickToMarkers: true,
         default: 2,
@@ -67,7 +70,7 @@ export const settings = definePluginSettings({
     verboseLogging: {
         type: OptionType.BOOLEAN,
         description:
-            "Show debug-level logs in the browser console (useful for troubleshooting Discord changes).",
+            "Raise Orion's debug messages to info level so they show in the console without switching it to Verbose (useful for troubleshooting Discord changes).",
         default: false,
     },
 });

--- a/tasks.ts
+++ b/tasks.ts
@@ -18,7 +18,7 @@ import type { Traffic } from "./traffic";
 import { settings } from "./settings";
 import { isSkippableQuest } from "./traffic";
 import type { DetectedTask, FakeGame, OrionRuntime, Quest, Stores, TaskInfo, TaskType } from "./types";
-import { rnd, sanitize, sleep } from "./util";
+import { debug, rnd, sanitize, sleep } from "./util";
 
 const logger = new Logger("OrionQuests");
 
@@ -42,6 +42,12 @@ export interface TaskCallbacks {
 
 export class TaskRunner {
     public skipped = new Set<string>();
+    /**
+     * Quests skipped only because the achievement bypass was switched off — a refusal
+     * to act, not a quest that can't be done. Tracked apart from `skipped` so turning
+     * the setting on can put them back in play. See retryConsentSkipped().
+     */
+    public consentSkipped = new Set<string>();
     private stores: Stores;
     private traffic: Traffic;
     private patcher: Patcher;
@@ -125,7 +131,7 @@ export class TaskRunner {
                 id: appId,
             };
         } catch (e: any) {
-            logger.debug(`[FetchGame] Fallback for ${appName}: ${e?.message ?? e}`);
+            debug(logger, `[FetchGame] Fallback for ${appName}: ${e?.message ?? e}`);
             const cleanName = sanitize(appName);
             const safeExe = `${cleanName.replace(/\s+/g, "")}.exe`;
             return {
@@ -170,7 +176,7 @@ export class TaskRunner {
             try {
                 await this.traffic.enqueue(`/quests/${q.id}/video-progress`, { timestamp: Number(cur.toFixed(6)) });
             } catch (e: any) {
-                logger.debug(`[Video] Initial ping failed: ${e?.message}`);
+                debug(logger, `[Video] Initial ping failed: ${e?.message}`);
             }
         }
 
@@ -269,8 +275,8 @@ export class TaskRunner {
                 cleaned = true;
                 clearTimeout(safetyTimer);
                 clearTimeout(watchdogTimer);
-                try { cleanupHook(); } catch (e: any) { logger.debug(`[Task] Cleanup: ${e?.message}`); }
-                try { this.stores.Dispatcher?.unsubscribe(HEARTBEAT_EVT, check); } catch (e: any) { logger.debug(`[Dispatcher] Unsubscribe failed: ${e?.message}`); }
+                try { cleanupHook(); } catch (e: any) { debug(logger, `[Task] Cleanup: ${e?.message}`); }
+                try { this.stores.Dispatcher?.unsubscribe(HEARTBEAT_EVT, check); } catch (e: any) { debug(logger, `[Dispatcher] Unsubscribe failed: ${e?.message}`); }
                 this.runtime.cleanups.delete(finish);
             };
 
@@ -341,7 +347,7 @@ export class TaskRunner {
                 failCount = 0;
                 if (cur >= t.target) {
                     try { await this.traffic.enqueue(`/quests/${q.id}/heartbeat`, { stream_key: key, terminal: true }); }
-                    catch (e: any) { logger.debug(`[ACTIVITY] Final heartbeat failed: ${e?.message}`); }
+                    catch (e: any) { debug(logger, `[ACTIVITY] Final heartbeat failed: ${e?.message}`); }
                     break;
                 }
             } catch (e: any) {
@@ -472,7 +478,7 @@ export class TaskRunner {
                     const ours = (after?.body || []).filter((tk: any) => tk.application?.id === appId && !snap.has(tk.id));
                     for (const g of ours) await this.stores.API.del({ url: `/oauth2/tokens/${g.id}` });
                 } catch (e: any) {
-                    logger.debug(`[Bypass] Deauthorize cleanup non-fatal: ${e?.message}`);
+                    debug(logger, `[Bypass] Deauthorize cleanup non-fatal: ${e?.message}`);
                 }
             }
         }
@@ -527,10 +533,31 @@ export class TaskRunner {
         const bypassed = await this.bypassAchievement(q, t);
         if (bypassed) return this.cb.onComplete(q, t);
 
-        // both auto-paths failed: skip the quest. no more 25-min passive wait.
         if (!this.runtime.running) return;
+
+        // A bypass that never ran because the consent toggle is off is not the same as one
+        // that ran and failed. Recorded separately so switching the toggle on returns the
+        // quest to the queue — otherwise it stays in `skipped` for the life of the run and
+        // the setting looks like it did nothing.
+        if (!settings.store.achievementBypass) {
+            this.consentSkipped.add(q.id);
+            return this.failTask(q, t, "Achievement bypass is off in settings");
+        }
+
+        // both auto-paths failed: skip the quest. no more 25-min passive wait.
         logger.warn(`[Task] Skipping "${t.name}" — no auto-completion path worked (heartbeat rejected, bypass blocked). Likely age-gated/delisted on your account.`);
         return this.failTask(q, t, "Cannot auto-complete");
+    }
+
+    /**
+     * Return quests that were skipped only for want of consent, so the next cycle picks them
+     * up again. Called when the achievement bypass is switched on while the engine runs.
+     */
+    retryConsentSkipped(): number {
+        let restored = 0;
+        for (const id of this.consentSkipped) if (this.skipped.delete(id)) restored++;
+        this.consentSkipped.clear();
+        return restored;
     }
 
     private findChannel(): string | null {
@@ -544,7 +571,7 @@ export class TaskRunner {
             }
             return null;
         } catch (e: any) {
-            logger.debug(`[Task] Channel lookup error: ${e?.message}`);
+            debug(logger, `[Task] Channel lookup error: ${e?.message}`);
             return null;
         }
     }

--- a/traffic.ts
+++ b/traffic.ts
@@ -15,7 +15,7 @@
 
 import { Logger } from "@utils/Logger";
 
-import { rnd, sleep } from "./util";
+import { debug, rnd, sleep } from "./util";
 
 const logger = new Logger("OrionQuests");
 
@@ -111,7 +111,7 @@ export class Traffic {
                         }, delay + retryJitter);
                     }
                 } else if (err.isClientError) {
-                    logger.debug(`[Network] HTTP ${err.status}: ${req.url}`);
+                    debug(logger, `[Network] HTTP ${err.status}: ${req.url}`);
                     req.reject(e);
                 } else {
                     logger.error(`[Network] Request to ${req.url} failed: ${err.message}`);

--- a/util.ts
+++ b/util.ts
@@ -4,6 +4,24 @@
  * SPDX-License-Identifier: MIT
  */
 
+import type { Logger } from "@utils/Logger";
+
+import { settings } from "./settings";
+
+/**
+ * Debug output, gated by the verboseLogging setting.
+ *
+ * Vencord's Logger.debug always calls console.debug, and browsers hide that level
+ * unless the console is switched to Verbose — so the setting had nothing to switch:
+ * every debug line was emitted either way, and whether you saw it depended on a
+ * DevTools filter. With the setting on these go out at info level, where they show
+ * by default; with it off the behaviour is unchanged.
+ */
+export function debug(logger: Logger, ...args: any[]): void {
+    if (settings.store.verboseLogging) logger.info(...args);
+    else logger.debug(...args);
+}
+
 export const sleep = (ms: number): Promise<void> =>
     new Promise(r => setTimeout(r, ms));
 


### PR DESCRIPTION
## Summary

Two plugin settings did not do what their descriptions promised, found while auditing every setting for the gap between when it is read and when it takes effect. A third is fine but undocumented, so its description now says how it behaves.

## Why

1. **`Verbose logging` was inert.** It is defined in `settings.ts` and read nowhere in the plugin — no reference exists outside its own definition. Independently, Vencord's `Logger.debug` calls `console.debug` with no gate of its own, and browsers hide that level unless the console is switched to Verbose. So every debug line was emitted whatever the toggle said, and whether the user saw any of them came down to a DevTools filter the setting has no influence over. The description promised the one thing it could not deliver.

2. **Enabling `Try achievement bypass` mid-run left already-skipped quests skipped.** When the bypass is off, `bypassAchievement` logs "Enable it in OrionQuests settings if you want it" and returns false; `ACHIEVEMENT` then calls `failTask`, which adds the quest to `skipped` — the same set used for quests that genuinely cannot be completed. `activeQuests()` filters on that set for the life of the `TaskRunner`, so a user who reads that message and acts on it sees nothing happen. Only a full stop/start clears it. A refusal to act for want of consent is not the same fact as a quest that cannot be done, and it should not be recorded as one.

3. **The concurrency sliders are read when a cycle starts.** That is the right behaviour — you cannot resize a pool that is already running — but nothing said so, and with tasks running up to 25 minutes the delay is long enough to look like the slider is broken.

## Changes

- Debug output goes through a single `debug(logger, …)` helper gated by `verboseLogging`: on, the message is raised to info level where it shows without touching the console filter; off, it stays at debug level, exactly as before. No diagnostics are lost in either position. 14 call sites across `orion.ts`, `patcher.ts`, `tasks.ts`, `traffic.ts`.
- `TaskRunner` tracks consent-gated skips in `consentSkipped`, apart from `skipped`. `retryConsentSkipped()` returns them to the queue, and the engine calls it when `achievementBypass` is switched on, so the quests are retried on the next cycle.
- New `hooks.ts`: a bridge with no imports of its own, so `settings.ts` can notify the engine without importing `orion.ts` and closing a cycle. The engine registers handlers at start and clears them in `stopOrion`, so a hook never outlives the run it belongs to.
- Setting descriptions corrected for `verboseLogging`, `achievementBypass`, and both concurrency sliders.

## Testing

- [x] `pnpm run testTsc` against a fresh Vencord clone with the plugin in `src/userplugins/` — clean, exit 0.
- [x] `pnpm build` — succeeds, plugin reaches both the renderer and main-process bundles.
- [x] `npx eslint` under Vencord's own config, diffed against a pristine `main` checkout linted the same way — no new errors. (Both trip `simple-header` on every file; that rule expects Vencord's own licence header and is not this repo's style.)
- [x] `node --check index.js` — untouched apart from the version constant, syntax clean.
- [ ] Not exercised by hand in a live client. The `verboseLogging` change is verifiable in one step — toggle it and watch Orion's debug lines appear at normal console level — and the bypass retry needs a live `ACHIEVEMENT_IN_ACTIVITY` quest skipped with the setting off, then the setting switched on mid-run. Happy to have either confirmed before merge.

## Checklist

- [x] `CONFIG.VERSION` bumped (if user-facing).
- [x] README changelog updated at the top of the list.
- [x] ARCHITECTURE.md updated if structure changed. (`hooks.ts` added to the file layout.)
- [x] Commit messages follow conventional commit style.
- [x] No debug `console.log` left behind.

Only plugin sources changed here; `index.js` carries the version constant alone, so `docs/VENCORD-PLUGIN.md`'s parity line moves with it.

Numbered **v4.9.11** assuming the three other pending PRs (v4.9.8, v4.9.9, v4.9.10) merge first. The changelog insertion point conflicts with all of them, since each adds a section directly under `## Changelog`. Happy to renumber or drop the version bump, whichever suits your release flow.
