### PR TITLE
fix(installer): the vencord bundle only ever handled Discord Stable

### DIFF
--- a/tools/orion-vencord-bundle/INSTALL.cmd
+++ b/tools/orion-vencord-bundle/INSTALL.cmd
@@ -1,4 +1,5 @@
 @echo off
+setlocal
 title Orion Quests - Installer
 color 0B
 echo.
@@ -22,9 +23,13 @@ if not exist "%APPDATA%\Vencord\dist\" (
     exit /b 1
 )
 
-:: 2) Close Discord before copying
+:: 2) Close Discord before copying. Vencord keeps one shared dist folder for every
+::    branch, so a running Canary or PTB locks the same files Stable would - close
+::    all three, and remember which ones were open so we reopen exactly those.
 echo  [1/4] Closing Discord...
-taskkill /F /IM Discord.exe >nul 2>&1
+call :stopFlavor Discord
+call :stopFlavor DiscordCanary
+call :stopFlavor DiscordPTB
 taskkill /F /IM DiscordSystemHelper.exe >nul 2>&1
 ping -n 3 127.0.0.1 >nul
 
@@ -38,14 +43,17 @@ if errorlevel 1 (
     color 0C
     echo.
     echo  ERROR copying the files. Make sure you extracted the whole zip
-    echo  (the "dist" folder has to sit right next to this .cmd).
+    echo  ^(the "dist" folder has to sit right next to this .cmd^).
     pause
     exit /b 1
 )
 
-:: 4) Reopen Discord
+:: 4) Reopen whatever we closed
 echo  [3/4] Reopening Discord...
-start "" "%LOCALAPPDATA%\Discord\Update.exe" --processStart Discord.exe
+call :startFlavor Discord
+call :startFlavor DiscordCanary
+call :startFlavor DiscordPTB
+if not defined ORION_STARTED call :startFallback
 ping -n 5 127.0.0.1 >nul
 
 echo  [4/4] Done!
@@ -67,3 +75,42 @@ echo     /orion stop     -- stop
 echo     /orion status   -- see progress
 echo.
 pause
+exit /b 0
+
+
+:: ── helpers ───────────────────────────────────────────────────
+
+:: Close one Discord build if it is running, and remember that it was.
+:stopFlavor
+tasklist /FI "IMAGENAME eq %~1.exe" 2>nul | find /I "%~1.exe" >nul
+if errorlevel 1 goto :eof
+set "ORION_WASRUNNING_%~1=1"
+taskkill /F /IM %~1.exe >nul 2>&1
+goto :eof
+
+:: Reopen one build, but only the ones we closed ourselves - a Stable-only user
+:: should not end up with Canary launched at them.
+:startFlavor
+if not defined ORION_WASRUNNING_%~1 goto :eof
+if not exist "%LOCALAPPDATA%\%~1\Update.exe" goto :eof
+start "" "%LOCALAPPDATA%\%~1\Update.exe" --processStart %~1.exe
+set "ORION_STARTED=1"
+goto :eof
+
+:: Discord was already closed before this ran, so there is nothing to put back.
+:: Start it anyway when only one build is installed and the choice is obvious.
+:startFallback
+set "ORION_ONLY="
+set "ORION_COUNT=0"
+for %%F in (Discord DiscordCanary DiscordPTB) do (
+    if exist "%LOCALAPPDATA%\%%F\Update.exe" (
+        set /a ORION_COUNT+=1
+        set "ORION_ONLY=%%F"
+    )
+)
+if "%ORION_COUNT%"=="1" (
+    start "" "%LOCALAPPDATA%\%ORION_ONLY%\Update.exe" --processStart %ORION_ONLY%.exe
+    goto :eof
+)
+echo        Discord was not running, so it was not reopened - open it yourself.
+goto :eof


### PR DESCRIPTION
Closes #69.

`INSTALL.cmd` killed `Discord.exe` and reopened `%LOCALAPPDATA%\Discord\Update.exe`, both hardcoded. On a Canary or PTB machine that closes nothing and reopens nothing, since `%LOCALAPPDATA%\Discord` doesn't exist there. The reporter says they patch the script by hand after every install.

The copy itself was already fine for Canary. Vencord keeps one dist folder for every branch (`FilesDir = BaseDir/dist` in the installer's `patcher.go`), so there's no per-flavour destination to pick — what was wrong is only which client gets closed and reopened. And a Canary left running holds exactly the files Stable would have held, so it isn't only the reopen that breaks.

So all three branches get closed, and the ones that were actually open get reopened. Reopening everything installed instead would launch Canary at someone who only ever runs Stable, which is why it tracks what it closed. If Discord was already shut before the installer ran there's nothing to put back, so it starts the only installed branch when there's just one and otherwise says so rather than guessing.

While testing I hit a second thing, and it's on `main` today rather than something this PR introduces. The error message under the copy step reads `(the "dist" folder has to sit right next to this .cmd)`, and those parens are unescaped inside the `if errorlevel 1 (` block. cmd parses a block before deciding whether to run it, so the stray `)` ends the block early and the leftover `.` aborts the script — on every run, whether or not the copy failed:

```
 [2/4] Copying files into Vencord...
. was unexpected at this time.
```

The installer dies right there. No reopen, and none of the enable-the-plugin instructions. Escaping the parens fixes it, and I verified the failure against a pristine checkout of `main` first so it isn't an artifact of my changes.

On testing: I ran the script against a fake `tasklist` and a fake `%LOCALAPPDATA%` over six cases — Stable+Canary open, Canary only, Stable only, nothing open with two branches installed, nothing open with one, and Canary open but not installed. Each closed and reopened exactly the expected set. The two lines that talk to the real system, the `tasklist | find` check and the `if exist ...\Update.exe` check, I also ran unmodified against a live machine with Stable and Canary running and PTB absent, and they read all three correctly. What I have not done is a full install on a Canary-only machine, which is the reporter's actual setup, so that's worth a second pair of eyes before merge.

I left `CONFIG.VERSION` and the changelog alone. `index.js` is untouched here and `package-release.ps1` refuses to build on version drift, so picking the next release number seemed like yours to make rather than mine. Happy to add both if you'd rather have them in this PR.
