### PR TITLE
Fix/windows installer hardening

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -1,0 +1,74 @@
+name: Installer regression
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, "feat/**", "fix/**"]
+    paths:
+      - "tools/orion-devbuild-installer/**"
+      - "tools/orion-vencord-bundle/**"
+      - "tools/package-release.ps1"
+      - "tools/tests/installer-regression.ps1"
+      - ".github/workflows/installer.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "tools/orion-devbuild-installer/**"
+      - "tools/orion-vencord-bundle/**"
+      - "tools/package-release.ps1"
+      - "tools/tests/installer-regression.ps1"
+      - ".github/workflows/installer.yml"
+
+jobs:
+  windows-installer:
+    name: Windows installer / Node ${{ matrix.node }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ["22", "24", "25"]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Parse scripts with Windows PowerShell 5.1
+        shell: powershell
+        run: |
+          $failed = $false
+          Get-ChildItem tools -Recurse -Filter *.ps1 | ForEach-Object {
+              $tokens = $null
+              $errors = $null
+              [void][System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors)
+              foreach ($error in $errors) {
+                  Write-Error "$($_.FullName):$($error.Extent.StartLineNumber): $($error.Message)"
+                  $failed = $true
+              }
+          }
+          if ($failed) { exit 1 }
+
+      - name: Run regression suite with Windows PowerShell 5.1
+        shell: powershell
+        run: .\tools\tests\installer-regression.ps1
+
+      - name: Parse scripts with PowerShell 7
+        shell: pwsh
+        run: |
+          $failed = $false
+          Get-ChildItem tools -Recurse -Filter *.ps1 | ForEach-Object {
+              $tokens = $null
+              $errors = $null
+              [void][System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors)
+              foreach ($error in $errors) {
+                  Write-Error "$($_.FullName):$($error.Extent.StartLineNumber): $($error.Message)"
+                  $failed = $true
+              }
+          }
+          if ($failed) { exit 1 }
+
+      - name: Run regression suite with PowerShell 7
+        shell: pwsh
+        run: .\tools\tests\installer-regression.ps1

--- a/tools/orion-devbuild-installer/INSTALL-autoupdate.cmd
+++ b/tools/orion-devbuild-installer/INSTALL-autoupdate.cmd
@@ -1,3 +1,3 @@
 @echo off
 title Orion Quests - Vencord auto-update edition
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install-autoupdate.ps1"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install-autoupdate.ps1" %*

--- a/tools/orion-devbuild-installer/README.txt
+++ b/tools/orion-devbuild-installer/README.txt
@@ -16,12 +16,22 @@ How it differs from the simple bundle (orion-vencord-bundle):
 WHAT TO EXPECT (read this so you don't panic)
 ------------------------------------------------------------
   - It takes about 5 to 15 minutes and downloads roughly 300 MB.
+  - Before installing Node/Git or downloading Vencord, it checks which Discord
+    flavor will be patched. A usable target must have both an active app-* tree
+    and Discord's Update.exe; stale leftover Discord folders are ignored.
   - It will sit on "Installing dependencies" with fast scrolling text for a
-    while. THAT IS NORMAL. Do NOT close the window - closing it mid-way leaves
-    a half-finished install.
+    while. THAT IS NORMAL. Do NOT close the window.
+  - The Vencord build is transactional. After each successful managed build,
+    the installer writes a SHA-256 health stamp for patcher.js, preload.js,
+    renderer.js, and renderer.css. A previous dist is rollback-eligible only if
+    those hashes still match, OrionQuests is present, and patcher/preload/renderer
+    identify the same Vencord revision. A half-written or externally rebuilt dist
+    is never silently promoted to "known good" just because its files exist.
   - Needs Node.js 22+ and Git. If they're missing, the installer permanently
     installs them system-wide via winget, and each shows its own "Do you want
     to allow changes?" (UAC) box - click Yes.
+  - Node 25+ is supported. If Node does not include Corepack, the installer uses
+    npx with the exact pnpm version declared by Vencord instead.
 
 
 ------------------------------------------------------------
@@ -30,14 +40,26 @@ INSTALL
   1. Double-click INSTALL-autoupdate.cmd
   2. If it installs Node.js / Git, allow the UAC prompts (Yes). If it asks you
      to close and re-run afterwards, do that.
-  3. When it patches Discord, Windows may show a full-screen blue box:
+  3. If you have multiple Discord flavors installed, the installer prefers the
+     single flavor that is currently running. If that is still ambiguous it asks
+     you to choose stable, canary, or ptb instead of silently assuming Stable.
+     Advanced use: INSTALL-autoupdate.cmd -DiscordBranch canary
+     You can also use INSTALL-autoupdate.cmd -SkipInject to build without patching
+     Discord. The .cmd wrapper forwards these options to the PowerShell installer.
+     The flavor that is actually patched is always reopened; any other Discord
+     flavor that was already running is reopened too.
+  4. When it patches Discord, Windows may show a full-screen blue box:
      "Windows protected your PC". Click "More info", then "Run anyway".
      This is Vencord's own installer, freshly downloaded from GitHub; Windows
      flags it only because it's new/unsigned. If it ever names a publisher
      other than Vencord, stop.
-  4. When it finishes, Discord reopens. Go to Settings -> Plugins, search
+  5. When it finishes, Discord reopens. Go to Settings -> Plugins, search
      OrionQuests, and enable it. For achievement quests, also enable the
      "achievementBypass" toggle (off by default).
+
+If the installer says Orion was installed but Discord did not reopen, start the
+named client manually. If it still will not start, run the official Vencord
+installer and choose Repair before retrying Orion.
 
 
 ------------------------------------------------------------
@@ -48,38 +70,79 @@ IMPORTANT
     DO NOT move or delete that folder. Discord loads Vencord from it. If you
     delete it while it's installed, Discord won't start (see RECOVERY below).
 
+  - Keep this extracted installer folder if you want to use UPDATE.cmd or
+    UNINSTALL.cmd later. Those scripts depend on the helper files beside them.
+
   - Vencord updates itself normally after this (Settings -> Vencord -> Updater).
-    If an update ever says "Build failed", run UPDATE.cmd from this folder - it
-    does the full rebuild the in-app updater can't.
+    IMPORTANT: Vencord's in-app updater rebuilds the live dist directly and does
+    not update Orion's health stamp. If it ever says "Build failed", DO NOT close
+    or restart Discord first. While the current Discord session is still open,
+    run UPDATE.cmd from this installer folder. The managed updater installs
+    dependencies and rebuilds transactionally. If the live dist no longer matches
+    the last managed health stamp, it is not used as rollback state; a successful
+    managed build creates a fresh stamp.
+
+  - UPDATE.cmd and UNINSTALL.cmd preserve the Discord flavor(s) that were open.
+    They do not replace Canary/PTB with Stable just because Stable is installed,
+    and they leave Discord closed if it was already closed.
+
+  - Reopening Discord is verified. If Windows/Squirrel accepts the start command
+    but the Discord process never appears, the script reports a warning instead
+    of silently printing success as if the client reopened normally.
+
+  - If Discord refuses to close within 15 seconds, install/update/uninstall stops
+    instead of modifying files while the client is still alive. Close Discord
+    manually and retry.
 
   - WHEN DISCORD ITSELF UPDATES, Vencord normally carries the patch over on its
     own: it notices the new version as Discord is closing and re-applies itself.
     That only works if Discord shuts down properly, so if Discord was force-closed
     (Task Manager, a crash, or the PC cutting out) the patch can be left behind in
     the old version's folder and the plugin will be gone on next launch. Nothing is
-    broken and nothing is lost - just double-click INSTALL-autoupdate.cmd again and
-    it re-patches the new version in seconds, reusing everything already downloaded.
+    broken and nothing is lost - run INSTALL-autoupdate.cmd again from this
+    installer folder to re-patch the new version while reusing everything already
+    downloaded.
 
 
 ------------------------------------------------------------
 UNINSTALL
 ------------------------------------------------------------
-  - Double-click UNINSTALL.cmd. It restores Discord to normal, then you can
-    delete the OrionVencord folder. (Node.js and Git stay installed; UNINSTALL
-    tells you how to remove those too if you want.)
+  - Run UNINSTALL.cmd from this installer folder. It restores Discord to normal,
+    then you can delete the OrionVencord folder. (Node.js and Git stay installed;
+    UNINSTALL tells you how to remove those too if you want.)
 
 
 ------------------------------------------------------------
 RECOVERY (if something goes wrong)
 ------------------------------------------------------------
-  - If Discord won't open: go to
-    %LOCALAPPDATA%\Discord\app-<version>\resources
-    delete "app.asar", and rename "_app.asar" to "app.asar".
-    Discord will open normally again (without the plugin). Then you can re-run
-    INSTALL-autoupdate.cmd if you want it back.
-  - If an update says "Build failed": run UPDATE.cmd.
-  - If the OrionVencord folder got into a weird state: delete it and re-run
-    INSTALL-autoupdate.cmd.
+  - If Discord won't open, use the root for the flavor you patched:
+      Stable:  %LOCALAPPDATA%\Discord\app-<version>\resources
+      Canary:  %LOCALAPPDATA%\DiscordCanary\app-<version>\resources
+      PTB:     %LOCALAPPDATA%\DiscordPTB\app-<version>\resources
+
+    IMPORTANT: check that "_app.asar" exists AND is not 0 bytes BEFORE changing
+    anything. A missing or empty _app.asar is not a safe recovery copy.
+
+    If _app.asar exists and is non-empty:
+      1. Rename the current "app.asar" to "app.asar.orion-broken"
+         (do NOT delete it first).
+      2. Rename "_app.asar" to "app.asar".
+      3. Start Discord. If it opens normally, you may delete
+         "app.asar.orion-broken" afterwards.
+
+    If _app.asar is missing or empty, do not delete or rename app.asar. Run the
+    official Vencord installer (vencord.dev/download) and choose Repair/Uninstall.
+    This avoids turning a recoverable install into one with no usable app.asar.
+
+  - If managed UPDATE.cmd says the Vencord build failed, a previous dist is only
+    restored automatically when it still matches the SHA-256 health stamp from a
+    successful managed build. An unverified mixed/externally rebuilt dist is never
+    used as rollback just because all four filenames exist.
+  - If the in-app updater says "Build failed", keep the current Discord session
+    open and run the managed UPDATE.cmd before the next Discord restart.
+  - If the OrionVencord folder got into a weird state: do NOT delete it while
+    Discord still points at it. First run the official Vencord installer and
+    choose Repair/Uninstall, confirm Discord opens normally, then delete it.
   - Last resort: run the official Vencord installer (vencord.dev/download) and
     pick Uninstall or Repair.
 

--- a/tools/orion-devbuild-installer/install-autoupdate.ps1
+++ b/tools/orion-devbuild-installer/install-autoupdate.ps1
@@ -4,41 +4,37 @@
   Builds Vencord from source with the OrionQuests plugin baked in, as a real git
   clone. Because the plugin lives in src/userplugins (gitignored upstream) and the
   install is a git checkout, Vencord's own updater keeps working: it git-pulls and
-  rebuilds, and the plugin is recompiled back in every time. This is the heavier,
-  correct alternative to the prebuilt bundle (which freezes Vencord).
+  rebuilds, and the plugin is recompiled back in every time.
 
-  Flow: ensure Node 22+ and Git (winget if missing) -> clone/pull Vencord into
-  %LOCALAPPDATA%\OrionVencord -> drop the plugin -> pnpm install -> build -> verify
-  the plugin is in the build -> patch Discord (inject). Build happens BEFORE inject.
-  The inject step does NOT trust the installer's exit code (Vencord's runInstaller
-  swallows CLI failures and still exits 0); it verifies Discord's app.asar actually
-  points at this build, and if not it rolls back and directly restores the original
-  app.asar so Discord always boots.
-
-  Pass -SkipInject to do everything except patch Discord (used for testing).
+  Flow: preflight Discord -> ensure Node 22+ and Git (winget if missing) -> clone/pull
+  Vencord into %LOCALAPPDATA%\OrionVencord -> drop the plugin -> pnpm install ->
+  transactional build -> verify -> patch the selected Discord flavor. Build happens
+  BEFORE inject. Pass -SkipInject to do everything except patch Discord.
 #>
-param([switch]$SkipInject)
+param(
+    [switch]$SkipInject,
+    [ValidateSet('stable', 'canary', 'ptb')][string]$DiscordBranch
+)
 
 $ErrorActionPreference = 'Stop'
-# let corepack fetch pnpm without an interactive y/n prompt
 $env:COREPACK_ENABLE_DOWNLOAD_PROMPT = '0'
 $InstallDir = Join-Path $env:LOCALAPPDATA 'OrionVencord'
 $PluginSrc  = Join-Path $PSScriptRoot 'plugin'
 $RepoUrl    = 'https://github.com/Vendicated/Vencord'
-# The plugin repo's root IS the plugin (moved there in v4.9.7 for exactly this), so it can be
-# cloned straight into src/userplugins and pulled on later updates.
 $PluginRepoUrl = 'https://github.com/nyxxbit/discord-quest-completer'
 
 function Info($m) { Write-Host $m -ForegroundColor Cyan }
 function Good($m) { Write-Host $m -ForegroundColor Green }
 function Warn($m) { Write-Host $m -ForegroundColor Yellow }
 function Pause2($m) { try { Read-Host $m } catch {} }
-function Fail($m) { Write-Host ""; Write-Host "  ERROR: $m" -ForegroundColor Red; Write-Host ""; Pause2 'Press Enter to exit'; exit 1 }
+function Fail($m) { Write-Host ''; Write-Host "  ERROR: $m" -ForegroundColor Red; Write-Host ''; Pause2 'Press Enter to exit'; exit 1 }
 function Have($c) { $null -ne (Get-Command $c -ErrorAction SilentlyContinue) }
 function RefreshPath { $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [Environment]::GetEnvironmentVariable('Path', 'User') }
 
-# Run a native command (git/corepack). They write progress to stderr, which PowerShell
-# would otherwise treat as fatal under -Stop. Run under Continue and judge by exit code.
+$Common = Join-Path $PSScriptRoot 'installer-common.ps1'
+if (-not (Test-Path -LiteralPath $Common -PathType Leaf)) { Fail 'installer-common.ps1 is missing. Extract the whole zip and keep the files together.' }
+. $Common
+
 function Step([string]$what, [scriptblock]$run) {
     $global:LASTEXITCODE = 0
     $prev = $ErrorActionPreference
@@ -47,8 +43,6 @@ function Step([string]$what, [scriptblock]$run) {
     if ($LASTEXITCODE -ne 0) { Fail "$what failed (exit code $LASTEXITCODE). See the output above." }
 }
 
-# winget returns nonzero for benign reasons (reboot-required, already-installed), so do NOT
-# gate on its exit code. Install, refresh PATH, and let the presence recheck be the oracle.
 function EnsureTool([string]$cmd, [string]$wingetId, [string]$name, [string]$url) {
     if (Have $cmd) { return }
     if (Have winget) {
@@ -61,43 +55,51 @@ function EnsureTool([string]$cmd, [string]$wingetId, [string]$name, [string]$url
     if (-not (Have $cmd)) { Fail "$name is still not available. Install it from $url , then close this window and run the installer again. (If winget asked for a reboot, reboot first.)" }
 }
 
-# Which Discord flavor is installed (for kill + relaunch). Stable preferred.
-function DiscordFlavor {
-    foreach ($f in @('Discord', 'DiscordCanary', 'DiscordPTB')) {
-        if (Test-Path (Join-Path $env:LOCALAPPDATA "$f\Update.exe")) { return $f }
-    }
-    return $null
-}
-function KillDiscord {
-    Get-Process Discord, DiscordCanary, DiscordPTB, DiscordSystemHelper, Update -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-    $deadline = (Get-Date).AddSeconds(15)
-    while (((Get-Process Discord, DiscordCanary, DiscordPTB -ErrorAction SilentlyContinue) | Measure-Object).Count -gt 0 -and (Get-Date) -lt $deadline) {
-        Start-Sleep -Milliseconds 500
+function Choose-DiscordBranch {
+    param([string[]]$Installed, [string[]]$Running, [string]$PreferredBranch)
+
+    try { return Resolve-DiscordFlavor -Installed $Installed -Running $Running -PreferredBranch $PreferredBranch }
+    catch {
+        if ($PreferredBranch -or $Installed.Count -eq 0) { Fail $_.Exception.Message }
+        Warn "  $($_.Exception.Message)"
+        Write-Host "  Installed: $($Installed -join ', ')"
+        if ($Running.Count -gt 0) { Write-Host "  Running:   $($Running -join ', ')" }
+        $choice = (Read-Host '  Type the Discord branch to patch (stable/canary/ptb)').Trim().ToLowerInvariant()
+        try { return Resolve-DiscordFlavor -Installed $Installed -Running @() -PreferredBranch $choice }
+        catch { Fail $_.Exception.Message }
     }
 }
 
-Write-Host "==============================================================" -ForegroundColor Magenta
-Write-Host "   Orion Quests - Vencord auto-update edition installer" -ForegroundColor Magenta
-Write-Host "==============================================================" -ForegroundColor Magenta
-Write-Host ""
-Write-Host " This builds Vencord from source with the plugin included, so Vencord keeps"
-Write-Host " auto-updating (unlike the simple bundle, which freezes it)."
-Write-Host ""
-Write-Host " Expect 5-15 minutes and about 300 MB of downloads. It will sit on" -ForegroundColor Yellow
+Write-Host '==============================================================' -ForegroundColor Magenta
+Write-Host '   Orion Quests - Vencord auto-update edition installer' -ForegroundColor Magenta
+Write-Host '==============================================================' -ForegroundColor Magenta
+Write-Host ''
+Write-Host ' This builds Vencord from source with the plugin included, so Vencord keeps'
+Write-Host ' auto-updating (unlike the simple bundle, which freezes it).'
+Write-Host ''
+Write-Host ' Expect 5-15 minutes and about 300 MB of downloads. It will sit on' -ForegroundColor Yellow
 Write-Host " 'Installing dependencies' with scrolling text for a while - that is normal," -ForegroundColor Yellow
-Write-Host " do NOT close the window." -ForegroundColor Yellow
-Write-Host ""
-Write-Host " It installs into:" -NoNewline; Write-Host " $InstallDir" -ForegroundColor Yellow
-Write-Host " Do NOT move or delete that folder afterwards - Discord loads Vencord from it." -ForegroundColor Yellow
-Write-Host ""
+Write-Host ' do NOT close the window.' -ForegroundColor Yellow
+Write-Host ''
+Write-Host ' It installs into:' -NoNewline; Write-Host " $InstallDir" -ForegroundColor Yellow
+Write-Host ' Do NOT move or delete that folder afterwards - Discord loads Vencord from it.' -ForegroundColor Yellow
+Write-Host ''
 if (-not (Test-Path $PluginSrc)) { Fail "plugin source folder not found next to this script ($PluginSrc). Extract the whole zip and keep the files together." }
 
-# ---- 1. prerequisites: Node 22+ and Git ----------------------------------------
-Info "[1/6] Checking Node.js and Git..."
+# Fail fast on Discord selection before installing system-wide prerequisites or making the
+# user wait through a Vencord build. -SkipInject intentionally needs no Discord install.
+$targetBranch = $null
+if (-not $SkipInject) {
+    Info '[preflight] Checking the Discord client to patch...'
+    $installedPreflight = @(Get-InstalledDiscordFlavors)
+    $runningPreflight = @(Get-RunningDiscordFlavors)
+    $targetBranch = Choose-DiscordBranch -Installed $installedPreflight -Running $runningPreflight -PreferredBranch $DiscordBranch
+    Good "  Target selected: Discord $targetBranch"
+}
+
+Info '[1/6] Checking Node.js and Git...'
 EnsureTool 'node' 'OpenJS.NodeJS.LTS' 'Node.js' 'https://nodejs.org'
 EnsureTool 'git'  'Git.Git'           'Git'     'https://git-scm.com'
-if (-not (Have corepack)) { Fail "corepack is missing (it ships with Node 16.9+). Reinstall Node LTS and re-run." }
-# Vencord now requires Node 22+. A pre-existing older Node would pass EnsureTool but fail the build.
 $nodeMajor = 0; try { $nodeMajor = [int]((node -v).TrimStart('v').Split('.')[0]) } catch {}
 if ($nodeMajor -lt 22) {
     if (Have winget) {
@@ -112,17 +114,16 @@ if ($nodeMajor -lt 22) {
 }
 Good "  Node $(node -v), $(git --version)"
 
-# ---- 2. clone or update Vencord ------------------------------------------------
 Info "[2/6] Getting Vencord source into $InstallDir ..."
 if (Test-Path (Join-Path $InstallDir '.git')) {
-    Warn "  Existing clone found - updating it..."
+    Warn '  Existing clone found - updating it...'
     $global:LASTEXITCODE = 0
     $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
     git -C $InstallDir pull --ff-only --quiet
     $pullCode = $LASTEXITCODE
     $ErrorActionPreference = $prev
     if ($pullCode -ne 0) {
-        Warn "  Fast-forward failed (upstream history changed) - hard-resetting to origin/main..."
+        Warn '  Fast-forward failed (upstream history changed) - hard-resetting to origin/main...'
         Step 'git fetch' { git -C $InstallDir fetch --depth 1 --quiet origin main }
         Step 'git reset' { git -C $InstallDir reset --hard --quiet FETCH_HEAD }
     }
@@ -131,112 +132,152 @@ if (Test-Path (Join-Path $InstallDir '.git')) {
     Step 'git clone' { git clone --depth 1 --quiet $RepoUrl $InstallDir }
 }
 
-# ---- 3. drop the plugin into src/userplugins ------------------------------------
-# Clone it rather than copy it. Copying froze whoever installed on the version their zip
-# happened to ship, because UPDATE.cmd re-copied that same folder every time: it pulled
-# Vencord and then put the old plugin straight back. Cloning gives the plugin its own git
-# checkout, so UPDATE.cmd can pull it like any other repo and a user is never stranded on
-# the release they first downloaded. Falls back to the bundled copy when git cannot reach
-# GitHub, so an offline or firewalled install still ends up with a working plugin.
-Info "[3/6] Adding the OrionQuests plugin..."
+Info '[3/6] Adding the OrionQuests plugin...'
 $dest = Join-Path $InstallDir 'src\userplugins\orionQuests'
-if (Test-Path $dest) { Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue }
+$pluginReady = $false
+$existingCheckoutUsable = $false
+if (Test-Path (Join-Path $dest '.git')) {
+    $existingCheckoutUsable = Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf
+    $updatedFromGit = $false
+    $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    try {
+        git -C $dest pull --ff-only --quiet
+        $pullCode = $LASTEXITCODE
+        if ($pullCode -eq 0) {
+            $updatedFromGit = Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf
+        } else {
+            git -C $dest fetch --depth 1 --quiet origin HEAD
+            $fetchCode = $LASTEXITCODE
+            $resetCode = 1
+            if ($fetchCode -eq 0) {
+                git -C $dest reset --hard --quiet FETCH_HEAD
+                $resetCode = $LASTEXITCODE
+            }
+            $updatedFromGit = ($fetchCode -eq 0 -and $resetCode -eq 0 -and (Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf))
+        }
+    } finally {
+        $ErrorActionPreference = $prev
+    }
 
-$cloned = $false
-$prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
-git clone --depth 1 --quiet $PluginRepoUrl $dest 2>&1 | Out-Null
-if ($LASTEXITCODE -eq 0 -and (Test-Path (Join-Path $dest 'index.tsx'))) { $cloned = $true }
-$ErrorActionPreference = $prev
-
-if ($cloned) {
-    Good "  Plugin cloned from $PluginRepoUrl (UPDATE.cmd will keep it current)."
-} else {
-    Warn "  Couldn't clone the plugin, falling back to the copy in this zip."
-    Warn "  UPDATE.cmd will keep Vencord current but not the plugin, so re-download the zip for new Orion releases."
-    if (Test-Path $dest) { Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue }
-    New-Item -ItemType Directory -Force -Path $dest | Out-Null
-    Copy-Item (Join-Path $PluginSrc '*') $dest -Recurse -Force
+    if ($updatedFromGit) {
+        Good '  Existing plugin checkout updated from git.'
+        $pluginReady = $true
+    } elseif ($existingCheckoutUsable -and (Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf)) {
+        Warn "  Couldn't update the plugin from GitHub; keeping the existing checkout instead of replacing it with the bundled copy."
+        $pluginReady = $true
+    }
 }
 
-# ---- 4. install deps + 5. build ------------------------------------------------
+if (-not $pluginReady) {
+    if (Test-Path $dest) { Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue }
+    $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    git clone --depth 1 --quiet $PluginRepoUrl $dest 2>&1 | Out-Null
+    $cloned = ($LASTEXITCODE -eq 0 -and (Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf))
+    $ErrorActionPreference = $prev
+
+    if ($cloned) {
+        Good "  Plugin cloned from $PluginRepoUrl (UPDATE.cmd will keep it current)."
+        $pluginReady = $true
+    } else {
+        Warn "  Couldn't clone the plugin, falling back to the copy in this zip."
+        Warn '  UPDATE.cmd will keep Vencord current but not the plugin, so re-download the zip for new Orion releases.'
+        if (Test-Path $dest) { Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue }
+        New-Item -ItemType Directory -Force -Path $dest | Out-Null
+        Copy-Item (Join-Path $PluginSrc '*') $dest -Recurse -Force
+        if (-not (Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf)) { Fail 'bundled plugin copy is incomplete (index.tsx is missing).' }
+        $pluginReady = $true
+    }
+}
+
 Push-Location $InstallDir
 try {
-    Info "[4/6] Installing dependencies (this is the slow part - do not close the window)..."
-    # no version pin and no --frozen-lockfile: corepack reads the pnpm version from the
-    # clone's packageManager field (so it matches the lockfile), and a non-frozen install
-    # tolerates minor lockfile drift on whatever upstream commit the friend happened to clone.
-    Step 'pnpm install' { corepack pnpm install }
-    Info "[5/6] Building Vencord + plugin..."
-    Step 'pnpm build' { corepack pnpm run build }
-    if (-not (Test-Path 'dist\patcher.js')) { Fail "build produced no dist. Aborting before touching Discord." }
-    if (-not (Select-String -Path 'dist\renderer.js' -Pattern 'OrionQuests' -SimpleMatch -Quiet)) {
-        Fail "the plugin isn't in the build output. Aborting before touching Discord so nothing breaks."
-    }
-    Good "  Build OK and the plugin is in it."
+    try { $pnpm = Get-PnpmInvocation -PackageJsonPath (Join-Path $InstallDir 'package.json') }
+    catch { Fail $_.Exception.Message }
 
-    # ---- 6. inject (patch Discord) ---------------------------------------------
+    Info '[4/6] Installing dependencies (this is the slow part - do not close the window)...'
+    Step 'pnpm install' { Invoke-Pnpm -Invocation $pnpm -Arguments @('install') }
+    Info '[5/6] Building Vencord + plugin transactionally...'
+    try { Invoke-VencordBuildTransactional -InstallDir $InstallDir -Invocation $pnpm -RequiredMarker 'OrionQuests' }
+    catch { Fail $_.Exception.Message }
+    Good '  Build OK, all Vencord runtime files are present, and the plugin is in it.'
+
     if ($SkipInject) {
         Warn "[6/6] -SkipInject set: not patching Discord. Build is ready at $InstallDir\dist."
     } else {
-        Info "[6/6] Patching Discord..."
+        Info '[6/6] Patching Discord...'
+        # Re-read only the running set after the long build. The target was selected during
+        # preflight; a client the user opened meanwhile should be restored after injection too.
+        $runningBefore = @(Get-RunningDiscordFlavors)
+        $reopen = @(Get-DiscordReopenSet -RunningBefore $runningBefore -TargetBranch $targetBranch)
+
+        Write-Host "  Target: Discord $targetBranch" -ForegroundColor Cyan
         Write-Host "  Windows may show a blue 'Windows protected your PC' box - if so, click 'More info'" -ForegroundColor Yellow
         Write-Host "  then 'Run anyway'. It's Vencord's own installer, freshly downloaded from GitHub." -ForegroundColor Yellow
-        # Patch the detected Discord explicitly (-branch) so Vencord's CLI never drops into its
-        # interactive "Select Discord install to patch" arrow-key menu. Left interactive it stalls a
-        # headless/logged run and makes a non-technical friend guess at a TUI with no instructions.
-        $flavor = DiscordFlavor
-        if (-not $flavor) { Fail "No Discord install found to patch. Install Discord first, then re-run." }
-        $branch = switch ($flavor) { 'DiscordCanary' { 'canary' } 'DiscordPTB' { 'ptb' } default { 'stable' } }
-        KillDiscord
+
+        try { Stop-DiscordProcesses } catch { Fail $_.Exception.Message }
         $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
-        node scripts\runInstaller.mjs -- --install -branch $branch
+        node scripts\runInstaller.mjs -- --install -branch $targetBranch
         $injectCode = $LASTEXITCODE
         $ErrorActionPreference = $prev
 
-        # runInstaller.mjs swallows CLI failures and still exits 0, so do NOT trust $injectCode.
-        # Verify the patch actually landed: the newest Discord app.asar stub for the selected
-        # flavor must now point at THIS clone's patcher.js.
-        $discordRoot = Join-Path $env:LOCALAPPDATA $flavor
-        $asar = Get-ChildItem (Join-Path $discordRoot 'app-*\resources\app.asar') -ErrorAction SilentlyContinue |
-                Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        $discordRoot = Get-DiscordRoot -Branch $targetBranch
+        $resources = Select-VencordDiscordResourcesPath -DiscordRoot $discordRoot
+        $asarPath = if ($resources) { Join-Path $resources 'app.asar' } else { $null }
+        $patcherPath = Join-Path $InstallDir 'dist\patcher.js'
         $patched = $false
-        if ($asar) {
-            try { $txt = [IO.File]::ReadAllText($asar.FullName) } catch { $txt = '' }
-            if ($txt -like '*patcher.js*' -and $txt -like '*OrionVencord*') { $patched = $true }
+        if ($asarPath) {
+            $patched = Test-AppAsarPointsToPatcher -AppAsar $asarPath -PatcherPath $patcherPath
         }
+
         if ($injectCode -ne 0 -or -not $patched) {
             Warn "  Inject didn't verify - reverting so Discord isn't left half-patched..."
             $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
-            node scripts\runInstaller.mjs -- --uninstall -branch $branch 2>&1 | Out-Null
+            node scripts\runInstaller.mjs -- --uninstall -branch $targetBranch 2>&1 | Out-Null
+            $uninstallCode = $LASTEXITCODE
             $ErrorActionPreference = $prev
-            # If uninject no-ops too, restore the real asar directly so Discord at least boots vanilla.
-            if ($asar -and (Test-Path (Join-Path $asar.Directory.FullName '_app.asar'))) {
-                Remove-Item $asar.FullName -Force -ErrorAction SilentlyContinue
-                Rename-Item (Join-Path $asar.Directory.FullName '_app.asar') 'app.asar' -ErrorAction SilentlyContinue
+
+            # Trust the filesystem, not the uninstaller's exit code. If unpatch already
+            # restored app.asar, ownership verification is enough. Otherwise use the same
+            # checked restore helper as UNINSTALL.cmd and verify again before reopening.
+            $rollbackOk = $false
+            if ($asarPath -and (Test-Path -LiteralPath $asarPath -PathType Leaf)) {
+                $rollbackOk = -not (Test-AppAsarPointsToPatcher -AppAsar $asarPath -PatcherPath $patcherPath)
             }
-            Fail "patching Discord failed. Discord was restored to its original state - just reopen it."
+            if (-not $rollbackOk -and $asarPath) {
+                $rollbackOk = Restore-VencordAppAsar -AppAsar $asarPath -PatcherPath $patcherPath
+            }
+
+            if ($rollbackOk) {
+                $failedReopen = @(Start-DiscordFlavors -Branches $reopen)
+                $extra = if ($failedReopen.Count -gt 0) { " Discord was restored, but these clients did not reopen automatically: $($failedReopen -join ', '). Start them manually." } else { '' }
+                Fail "patching Discord $targetBranch failed. Discord was restored to its original state.$extra"
+            }
+
+            Warn "  Automatic rollback could not be verified (uninstaller exit code $uninstallCode)."
+            Fail "patching Discord $targetBranch failed and rollback could not be verified. Discord was left closed. Run the official Vencord installer and choose Repair before reopening Discord."
         }
-        Good "  Discord patched (verified)."
-        if ($flavor) {
-            Start-Process (Join-Path $env:LOCALAPPDATA "$flavor\Update.exe") -ArgumentList '--processStart', "$flavor.exe" -ErrorAction SilentlyContinue
-        } else {
-            Warn "  Couldn't find Discord to reopen automatically - open it yourself."
+
+        Good "  Discord $targetBranch patched (verified)."
+        $failedReopen = @(Start-DiscordFlavors -Branches $reopen)
+        if ($failedReopen.Count -gt 0) {
+            Warn "  Orion is installed, but these Discord clients did not reopen automatically: $($failedReopen -join ', ')."
+            Warn '  Start them manually. If one still will not open, run the official Vencord installer and choose Repair.'
         }
     }
 } finally {
     Pop-Location
 }
 
-Write-Host ""
-Good "Done."
+Write-Host ''
+Good 'Done.'
 if (-not $SkipInject) {
-    Write-Host ""
-    Write-Host " NEXT: in Discord, open Settings -> Plugins, search OrionQuests, enable it." -ForegroundColor Cyan
+    Write-Host ''
+    Write-Host ' NEXT: in Discord, open Settings -> Plugins, search OrionQuests, enable it.' -ForegroundColor Cyan
     Write-Host "       For achievement quests, also enable the 'achievementBypass' toggle." -ForegroundColor Cyan
-    Write-Host "       Vencord auto-updates normally now, and the plugin rebuilds in on updates." -ForegroundColor Cyan
-    Write-Host "       If it ever says 'Build failed' after an update, run UPDATE.cmd from this folder." -ForegroundColor Cyan
-    Write-Host ""
-    Write-Host " To remove it later: run UNINSTALL.cmd from this folder." -ForegroundColor DarkGray
+    Write-Host '       Vencord auto-updates normally now, and the plugin rebuilds in on updates.' -ForegroundColor Cyan
+    Write-Host '       If an update ever says Build failed, run UPDATE.cmd from this installer folder.' -ForegroundColor Cyan
+    Write-Host ''
+    Write-Host ' To remove it later: run UNINSTALL.cmd from this installer folder.' -ForegroundColor DarkGray
 }
-Write-Host ""
+Write-Host ''
 Pause2 'Press Enter to close'

--- a/tools/orion-devbuild-installer/installer-common.ps1
+++ b/tools/orion-devbuild-installer/installer-common.ps1
@@ -1,0 +1,471 @@
+# Shared Windows installer helpers for install/update/uninstall.
+# Keep Discord discovery and process handling in one place so the three entry
+# points cannot silently disagree about Stable / Canary / PTB behavior.
+
+$script:DiscordFlavorInfo = [ordered]@{
+    stable = [pscustomobject]@{ Branch = 'stable'; Directory = 'Discord';       Process = 'Discord' }
+    canary = [pscustomobject]@{ Branch = 'canary'; Directory = 'DiscordCanary'; Process = 'DiscordCanary' }
+    ptb    = [pscustomobject]@{ Branch = 'ptb';    Directory = 'DiscordPTB';    Process = 'DiscordPTB' }
+}
+$script:VencordDesktopRuntimeFiles = @('patcher.js', 'preload.js', 'renderer.js', 'renderer.css')
+$script:VencordRevisionFiles = @('patcher.js', 'preload.js', 'renderer.js')
+
+function Get-DiscordFlavorInfo {
+    param([Parameter(Mandatory)][string]$Branch)
+    $key = $Branch.ToLowerInvariant()
+    if (-not $script:DiscordFlavorInfo.Contains($key)) { throw "Unsupported Discord branch '$Branch'. Expected stable, canary, or ptb." }
+    return $script:DiscordFlavorInfo[$key]
+}
+
+function Get-DiscordRoot {
+    param(
+        [Parameter(Mandatory)][string]$Branch,
+        [string]$LocalAppData = $env:LOCALAPPDATA
+    )
+    if ([string]::IsNullOrWhiteSpace($LocalAppData)) { throw 'LOCALAPPDATA is empty; cannot locate Discord.' }
+    $info = Get-DiscordFlavorInfo -Branch $Branch
+    return Join-Path $LocalAppData $info.Directory
+}
+
+function Select-VencordDiscordResourcesPath {
+    param([Parameter(Mandatory)][string]$DiscordRoot)
+
+    # Match Vencord Installer's Windows ParseDiscord rule: among valid app-* directories,
+    # keep the lexicographically greatest <app>/resources/app path. Do not substitute an
+    # mtime heuristic here; verification must inspect the same target the installer chose.
+    $bestKey = $null
+    $bestResources = $null
+    Get-ChildItem -LiteralPath $DiscordRoot -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+        if (-not $_.Name.StartsWith('app-', [StringComparison]::Ordinal)) { return }
+        $resources = Join-Path $_.FullName 'resources'
+        if (-not (Test-Path -LiteralPath $resources -PathType Container)) { return }
+        $key = Join-Path $resources 'app'
+        if ($null -eq $bestKey -or [string]::CompareOrdinal($key, $bestKey) -gt 0) {
+            $bestKey = $key
+            $bestResources = $resources
+        }
+    }
+    return $bestResources
+}
+
+function Test-VencordDistComplete {
+    param([Parameter(Mandatory)][string]$DistPath)
+    foreach ($name in $script:VencordDesktopRuntimeFiles) {
+        $path = Join-Path $DistPath $name
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $false }
+        try { if ((Get-Item -LiteralPath $path -ErrorAction Stop).Length -le 0) { return $false } }
+        catch { return $false }
+    }
+    return $true
+}
+
+function Get-VencordDistRevision {
+    param([Parameter(Mandatory)][string]$DistPath)
+
+    $revisions = @()
+    foreach ($name in $script:VencordRevisionFiles) {
+        $path = Join-Path $DistPath $name
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { return $null }
+        try {
+            $line = Select-String -LiteralPath $path -Pattern '^// Vencord ([0-9a-fA-F]+)$' | Select-Object -First 1
+            if (-not $line -or $line.Matches.Count -eq 0) { return $null }
+            $revisions += $line.Matches[0].Groups[1].Value.ToLowerInvariant()
+        } catch {
+            return $null
+        }
+    }
+
+    $unique = @($revisions | Select-Object -Unique)
+    if ($unique.Count -ne 1) { return $null }
+    return $unique[0]
+}
+
+function Test-OrionVencordDistSemantic {
+    param(
+        [Parameter(Mandatory)][string]$DistPath,
+        [string]$RequiredMarker = 'OrionQuests'
+    )
+
+    if (-not (Test-VencordDistComplete -DistPath $DistPath)) { return $false }
+    try {
+        if (-not (Select-String -LiteralPath (Join-Path $DistPath 'renderer.js') -Pattern $RequiredMarker -SimpleMatch -Quiet)) { return $false }
+    } catch {
+        return $false
+    }
+    return -not [string]::IsNullOrWhiteSpace((Get-VencordDistRevision -DistPath $DistPath))
+}
+
+function Get-OrionVencordHealthStampPath {
+    param([Parameter(Mandatory)][string]$InstallDir)
+    return Join-Path $InstallDir '.orion-dist-health.sha256'
+}
+
+function Get-VencordDistHashLines {
+    param([Parameter(Mandatory)][string]$DistPath)
+
+    foreach ($name in $script:VencordDesktopRuntimeFiles) {
+        $path = Join-Path $DistPath $name
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) { throw "runtime file '$name' is missing" }
+        $hash = (Get-FileHash -LiteralPath $path -Algorithm SHA256 -ErrorAction Stop).Hash.ToLowerInvariant()
+        "$name=$hash"
+    }
+}
+
+function Write-OrionVencordHealthStamp {
+    param(
+        [Parameter(Mandatory)][string]$InstallDir,
+        [Parameter(Mandatory)][string]$DistPath
+    )
+
+    $stamp = Get-OrionVencordHealthStampPath -InstallDir $InstallDir
+    $temporary = "$stamp.new"
+    $lines = [string[]]@(Get-VencordDistHashLines -DistPath $DistPath)
+    if ($lines.Count -ne $script:VencordDesktopRuntimeFiles.Count) { throw 'could not hash the complete Vencord runtime' }
+
+    try {
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+        [IO.File]::WriteAllLines($temporary, $lines, $utf8NoBom)
+        if (Test-Path -LiteralPath $stamp -PathType Leaf) {
+            [IO.File]::Replace($temporary, $stamp, $null)
+        } else {
+            [IO.File]::Move($temporary, $stamp)
+        }
+    } finally {
+        if (Test-Path -LiteralPath $temporary -PathType Leaf) { Remove-Item -LiteralPath $temporary -Force -ErrorAction SilentlyContinue }
+    }
+}
+
+function Test-OrionVencordDistHealthy {
+    param(
+        [Parameter(Mandatory)][string]$DistPath,
+        [string]$RequiredMarker = 'OrionQuests',
+        [Parameter(Mandatory)][string]$HealthStampPath
+    )
+
+    if (-not (Test-OrionVencordDistSemantic -DistPath $DistPath -RequiredMarker $RequiredMarker)) { return $false }
+    if (-not (Test-Path -LiteralPath $HealthStampPath -PathType Leaf)) { return $false }
+
+    try {
+        $expected = [string[]]@(Get-Content -LiteralPath $HealthStampPath -ErrorAction Stop | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $actual = [string[]]@(Get-VencordDistHashLines -DistPath $DistPath)
+        if ($expected.Count -ne $actual.Count) { return $false }
+        for ($i = 0; $i -lt $actual.Count; $i++) {
+            if (-not $expected[$i].Equals($actual[$i], [StringComparison]::OrdinalIgnoreCase)) { return $false }
+        }
+        return $true
+    } catch {
+        return $false
+    }
+}
+
+function Get-InstalledDiscordFlavors {
+    param([string]$LocalAppData = $env:LOCALAPPDATA)
+
+    # Orion must be able to reopen a selected target after patching it. A stale
+    # app-* directory without Squirrel's Update.exe is not a usable install for
+    # our lifecycle even though Vencord Installer can still parse the directory.
+    foreach ($branch in $script:DiscordFlavorInfo.Keys) {
+        $root = Get-DiscordRoot -Branch $branch -LocalAppData $LocalAppData
+        $update = Join-Path $root 'Update.exe'
+        if ((Test-Path -LiteralPath $update -PathType Leaf) -and (Select-VencordDiscordResourcesPath -DiscordRoot $root)) { $branch }
+    }
+}
+
+function Get-RunningDiscordFlavors {
+    foreach ($branch in $script:DiscordFlavorInfo.Keys) {
+        $info = Get-DiscordFlavorInfo -Branch $branch
+        if (Get-Process -Name $info.Process -ErrorAction SilentlyContinue | Select-Object -First 1) { $branch }
+    }
+}
+
+function Resolve-DiscordFlavor {
+    param(
+        [string[]]$Installed,
+        [string[]]$Running,
+        [ValidateSet('stable', 'canary', 'ptb')][string]$PreferredBranch
+    )
+
+    $installedSet = @($Installed | Where-Object { $_ } | ForEach-Object { $_.ToLowerInvariant() } | Select-Object -Unique)
+    $runningSet = @($Running | Where-Object { $_ } | ForEach-Object { $_.ToLowerInvariant() } | Where-Object { $_ -in $installedSet } | Select-Object -Unique)
+
+    if ($PreferredBranch) {
+        $preferred = $PreferredBranch.ToLowerInvariant()
+        if ($preferred -notin $installedSet) { throw "Discord $preferred is not installed or is not launchable." }
+        return $preferred
+    }
+
+    if ($runningSet.Count -eq 1) { return $runningSet[0] }
+    if ($runningSet.Count -gt 1) { throw "More than one Discord flavor is running: $($runningSet -join ', ')." }
+    if ($installedSet.Count -eq 1) { return $installedSet[0] }
+    if ($installedSet.Count -eq 0) { throw 'No supported launchable Discord desktop install was found.' }
+    throw "More than one Discord flavor is installed and none is running: $($installedSet -join ', ')."
+}
+
+function Get-DiscordReopenSet {
+    param(
+        [string[]]$RunningBefore,
+        [Parameter(Mandatory)][ValidateSet('stable', 'canary', 'ptb')][string]$TargetBranch
+    )
+
+    $result = @()
+    foreach ($branch in @($RunningBefore) + @($TargetBranch)) {
+        if ([string]::IsNullOrWhiteSpace($branch)) { continue }
+        $normalized = (Get-DiscordFlavorInfo -Branch $branch).Branch
+        if ($normalized -notin $result) { $result += $normalized }
+    }
+    return $result
+}
+
+function Test-IsDiscordUpdaterPath {
+    param(
+        [string]$Path,
+        [string[]]$DiscordRoots
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
+    try { $candidate = [IO.Path]::GetFullPath($Path) } catch { return $false }
+
+    foreach ($root in $DiscordRoots) {
+        if ([string]::IsNullOrWhiteSpace($root)) { continue }
+        try { $fullRoot = [IO.Path]::GetFullPath($root).TrimEnd('\', '/') } catch { continue }
+        if ($candidate.Equals((Join-Path $fullRoot 'Update.exe'), [StringComparison]::OrdinalIgnoreCase)) { return $true }
+        $prefix = $fullRoot + [IO.Path]::DirectorySeparatorChar
+        if ($candidate.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) { return $true }
+    }
+    return $false
+}
+
+function Test-AppAsarPointsToPatcher {
+    param(
+        [Parameter(Mandatory)][string]$AppAsar,
+        [Parameter(Mandatory)][string]$PatcherPath
+    )
+
+    try {
+        if (-not (Test-Path -LiteralPath $AppAsar -PathType Leaf)) { return $false }
+        $text = [IO.File]::ReadAllText($AppAsar)
+        $expected = [IO.Path]::GetFullPath($PatcherPath)
+        $serializedExpected = '"' + $expected.Replace('\', '\\') + '"'
+        return $text.IndexOf($serializedExpected, [StringComparison]::OrdinalIgnoreCase) -ge 0
+    } catch {
+        return $false
+    }
+}
+
+function Restore-VencordAppAsar {
+    param(
+        [Parameter(Mandatory)][string]$AppAsar,
+        [Parameter(Mandatory)][string]$PatcherPath
+    )
+
+    $resources = Split-Path -Parent $AppAsar
+    $backupAsar = Join-Path $resources '_app.asar'
+    if (-not (Test-Path -LiteralPath $backupAsar -PathType Leaf)) { return $false }
+    try { if ((Get-Item -LiteralPath $backupAsar -ErrorAction Stop).Length -le 0) { return $false } }
+    catch { return $false }
+    if (Test-AppAsarPointsToPatcher -AppAsar $backupAsar -PatcherPath $PatcherPath) { return $false }
+
+    $hadCurrent = Test-Path -LiteralPath $AppAsar -PathType Leaf
+    $temporaryAsar = Join-Path $resources ("app.asar.orion-rollback-" + [guid]::NewGuid().ToString('N'))
+    $movedCurrent = $false
+    $movedBackup = $false
+
+    try {
+        if ($hadCurrent) {
+            Rename-Item -LiteralPath $AppAsar -NewName (Split-Path -Leaf $temporaryAsar) -ErrorAction Stop
+            $movedCurrent = $true
+        }
+
+        Rename-Item -LiteralPath $backupAsar -NewName 'app.asar' -ErrorAction Stop
+        $movedBackup = $true
+
+        $restored = (Test-Path -LiteralPath $AppAsar -PathType Leaf) -and
+            ((Get-Item -LiteralPath $AppAsar -ErrorAction Stop).Length -gt 0) -and
+            -not (Test-AppAsarPointsToPatcher -AppAsar $AppAsar -PatcherPath $PatcherPath)
+        if (-not $restored) { throw 'restored app.asar did not verify' }
+
+        if ($movedCurrent -and (Test-Path -LiteralPath $temporaryAsar -PathType Leaf)) {
+            Remove-Item -LiteralPath $temporaryAsar -Force -ErrorAction SilentlyContinue
+        }
+        return $true
+    } catch {
+        if ($movedBackup -and (Test-Path -LiteralPath $AppAsar -PathType Leaf) -and
+            -not (Test-Path -LiteralPath $backupAsar -PathType Leaf)) {
+            try { Rename-Item -LiteralPath $AppAsar -NewName '_app.asar' -ErrorAction Stop } catch {}
+        }
+        if ($movedCurrent -and (Test-Path -LiteralPath $temporaryAsar -PathType Leaf) -and
+            -not (Test-Path -LiteralPath $AppAsar -PathType Leaf)) {
+            try { Rename-Item -LiteralPath $temporaryAsar -NewName 'app.asar' -ErrorAction Stop } catch {}
+        }
+        return $false
+    }
+}
+
+function Get-DiscordUpdaterProcesses {
+    $roots = @($script:DiscordFlavorInfo.Keys | ForEach-Object { Get-DiscordRoot -Branch $_ })
+    Get-Process Update -ErrorAction SilentlyContinue | ForEach-Object {
+        $path = $null
+        try { $path = $_.Path } catch {}
+        if (Test-IsDiscordUpdaterPath -Path $path -DiscordRoots $roots) { $_ }
+    }
+}
+
+function Stop-DiscordProcesses {
+    Get-Process Discord, DiscordCanary, DiscordPTB, DiscordSystemHelper -ErrorAction SilentlyContinue |
+        Stop-Process -Force -ErrorAction SilentlyContinue
+    Get-DiscordUpdaterProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
+
+    $deadline = (Get-Date).AddSeconds(15)
+    do {
+        $remainingClients = @(Get-Process Discord, DiscordCanary, DiscordPTB, DiscordSystemHelper -ErrorAction SilentlyContinue)
+        $remainingUpdaters = @(Get-DiscordUpdaterProcesses)
+        if ($remainingClients.Count -eq 0 -and $remainingUpdaters.Count -eq 0) { return }
+        if ((Get-Date) -ge $deadline) { break }
+        Start-Sleep -Milliseconds 500
+    } while ($true)
+
+    $remaining = @($remainingClients | ForEach-Object { $_.ProcessName }) + @($remainingUpdaters | ForEach-Object { $_.ProcessName })
+    throw "Discord did not fully exit within 15 seconds. Still running: $($remaining -join ', '). Close it manually and retry."
+}
+
+function Start-DiscordFlavors {
+    param(
+        [string[]]$Branches,
+        [string]$LocalAppData = $env:LOCALAPPDATA
+    )
+
+    $requested = @($Branches | Where-Object { $_ } | ForEach-Object { (Get-DiscordFlavorInfo -Branch $_).Branch } | Select-Object -Unique)
+    $failed = @()
+
+    foreach ($branch in $requested) {
+        $info = Get-DiscordFlavorInfo -Branch $branch
+        $update = Join-Path (Get-DiscordRoot -Branch $branch -LocalAppData $LocalAppData) 'Update.exe'
+        if (-not (Test-Path -LiteralPath $update -PathType Leaf)) {
+            $failed += $branch
+            continue
+        }
+        try {
+            Start-Process $update -ArgumentList '--processStart', "$($info.Process).exe" -ErrorAction Stop
+        } catch {
+            $failed += $branch
+        }
+    }
+
+    $pending = @($requested | Where-Object { $_ -notin $failed })
+    $deadline = (Get-Date).AddSeconds(20)
+    while ($pending.Count -gt 0 -and (Get-Date) -lt $deadline) {
+        $next = @()
+        foreach ($branch in $pending) {
+            $info = Get-DiscordFlavorInfo -Branch $branch
+            if (-not (Get-Process -Name $info.Process -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+                $next += $branch
+            }
+        }
+        $pending = @($next)
+        if ($pending.Count -gt 0) { Start-Sleep -Milliseconds 500 }
+    }
+
+    $failed += $pending
+    return @($failed | Select-Object -Unique)
+}
+
+function Get-PnpmInvocation {
+    param([Parameter(Mandatory)][string]$PackageJsonPath)
+
+    if (-not (Test-Path -LiteralPath $PackageJsonPath -PathType Leaf)) { throw "package.json not found at $PackageJsonPath" }
+    $package = Get-Content -LiteralPath $PackageJsonPath -Raw | ConvertFrom-Json
+    $spec = [string]$package.packageManager
+    if ($spec -notmatch '^pnpm@([^+\s]+)') { throw "Vencord package.json has no supported pnpm packageManager entry (got '$spec')." }
+    $version = $Matches[1]
+
+    if (Get-Command corepack -ErrorAction SilentlyContinue) {
+        return [pscustomobject]@{ Command = 'corepack'; Arguments = @('pnpm'); Version = $version }
+    }
+
+    if (Get-Command npx -ErrorAction SilentlyContinue) {
+        return [pscustomobject]@{ Command = 'npx'; Arguments = @('--yes', "pnpm@$version"); Version = $version }
+    }
+
+    throw 'Neither corepack nor npx is available. Reinstall a normal Node.js distribution and re-run.'
+}
+
+function Invoke-Pnpm {
+    param(
+        [Parameter(Mandatory)]$Invocation,
+        [string[]]$Arguments
+    )
+    $all = @($Invocation.Arguments) + @($Arguments)
+    & $Invocation.Command @all
+}
+
+function Invoke-VencordBuildTransactional {
+    param(
+        [Parameter(Mandatory)][string]$InstallDir,
+        [Parameter(Mandatory)]$Invocation,
+        [string]$RequiredMarker = 'OrionQuests'
+    )
+
+    $dist = Join-Path $InstallDir 'dist'
+    $healthStamp = Get-OrionVencordHealthStampPath -InstallDir $InstallDir
+    $snapshot = Join-Path ([IO.Path]::GetTempPath()) ("orion-vencord-dist-" + [guid]::NewGuid().ToString('N'))
+    $hadKnownGood = Test-OrionVencordDistHealthy -DistPath $dist -RequiredMarker $RequiredMarker -HealthStampPath $healthStamp
+
+    if ($hadKnownGood) {
+        New-Item -ItemType Directory -Force -Path $snapshot | Out-Null
+        Copy-Item (Join-Path $dist '*') $snapshot -Recurse -Force -ErrorAction Stop
+    }
+
+    $buildCode = 1
+    $buildException = $null
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $global:LASTEXITCODE = 0
+        try { Invoke-Pnpm -Invocation $Invocation -Arguments @('run', 'build') }
+        catch { $buildException = $_.Exception.Message }
+        $buildCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prev
+    }
+
+    $semantic = Test-OrionVencordDistSemantic -DistPath $dist -RequiredMarker $RequiredMarker
+    if (-not $buildException -and $buildCode -eq 0 -and $semantic) {
+        try {
+            Write-OrionVencordHealthStamp -InstallDir $InstallDir -DistPath $dist
+            if (Test-OrionVencordDistHealthy -DistPath $dist -RequiredMarker $RequiredMarker -HealthStampPath $healthStamp) {
+                Remove-Item -LiteralPath $snapshot -Recurse -Force -ErrorAction SilentlyContinue
+                return
+            }
+            $buildException = 'the Vencord runtime health stamp did not verify after it was written'
+        } catch {
+            $buildException = "could not persist the Vencord runtime health stamp: $($_.Exception.Message)"
+        }
+    }
+
+    $restoreOk = $true
+    try {
+        if (Test-Path -LiteralPath $dist) { Remove-Item -LiteralPath $dist -Recurse -Force -ErrorAction Stop }
+        if ($hadKnownGood) {
+            New-Item -ItemType Directory -Force -Path $dist | Out-Null
+            Copy-Item (Join-Path $snapshot '*') $dist -Recurse -Force -ErrorAction Stop
+            $restoreOk = Test-OrionVencordDistHealthy -DistPath $dist -RequiredMarker $RequiredMarker -HealthStampPath $healthStamp
+        } else {
+            Remove-Item -LiteralPath $healthStamp -Force -ErrorAction SilentlyContinue
+        }
+    } catch {
+        $restoreOk = $false
+    }
+
+    if (-not $restoreOk) {
+        if ($hadKnownGood -and (Test-Path -LiteralPath $snapshot -PathType Container)) {
+            throw "Vencord build failed and the previous stamped healthy dist could not be restored automatically. A recovery snapshot was kept at $snapshot. Leave Discord open if it is still running; before the next restart, run the official Vencord installer and choose Repair."
+        }
+        throw 'Vencord build failed and the partial dist could not be cleaned up. No stamped healthy Orion dist existed to snapshot. Leave Discord open if it is still running; before the next restart, run the official Vencord installer and choose Repair.'
+    }
+
+    Remove-Item -LiteralPath $snapshot -Recurse -Force -ErrorAction SilentlyContinue
+    $recovery = if ($hadKnownGood) { 'The previous stamped healthy Orion dist was restored.' } else { 'The partial build dist was removed; no unverified pre-existing dist was used as rollback.' }
+    if ($buildException) { throw "Vencord build failed: $buildException $recovery" }
+    if ($buildCode -ne 0) { throw "Vencord build failed (exit code $buildCode). $recovery" }
+    throw "Vencord build output failed semantic verification: it must contain the four Discord runtime files, the $RequiredMarker plugin, and one consistent Vencord revision across patcher/preload/renderer. $recovery"
+}

--- a/tools/orion-devbuild-installer/uninstall.ps1
+++ b/tools/orion-devbuild-installer/uninstall.ps1
@@ -1,37 +1,39 @@
 <#
   Uninstall the Orion Quests "auto-update edition".
 
-  Robust because the friend may have already deleted the OrionVencord clone (which would
-  brick Discord, since its app.asar stub require()s the clone's patcher.js). So we do NOT
-  depend on the clone: we restore Discord's original app.asar directly, for every flavor,
-  but only where the stub actually points at OUR OrionVencord install.
+  This does not depend on the OrionVencord clone surviving: it restores Discord's
+  original app.asar directly for every supported flavor, but only where the stub
+  actually points at this OrionVencord install.
 #>
 $ErrorActionPreference = 'Continue'
 $InstallDir = Join-Path $env:LOCALAPPDATA 'OrionVencord'
 
-Write-Host "Orion Quests - uninstalling the auto-update edition..." -ForegroundColor Cyan
+$Common = Join-Path $PSScriptRoot 'installer-common.ps1'
+if (-not (Test-Path -LiteralPath $Common -PathType Leaf)) {
+    Write-Host 'installer-common.ps1 is missing. Re-download/extract the full installer zip.' -ForegroundColor Red
+    try { Read-Host 'Press Enter to close' } catch {}
+    exit 1
+}
+. $Common
 
-# 1. close every Discord flavor + Squirrel updater, wait for them to actually exit
-Get-Process Discord, DiscordCanary, DiscordPTB, DiscordSystemHelper, Update -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-$deadline = (Get-Date).AddSeconds(15)
-while (((Get-Process Discord, DiscordCanary, DiscordPTB -ErrorAction SilentlyContinue) | Measure-Object).Count -gt 0 -and (Get-Date) -lt $deadline) { Start-Sleep -Milliseconds 500 }
+function Fail($m) {
+    Write-Host "ERROR: $m" -ForegroundColor Red
+    try { Read-Host 'Press Enter to close' } catch {}
+    exit 1
+}
 
-# 2. (No pnpm/CLI uninject step on purpose: Vencord's installer CLI is interactive and would stall
-#     on a friend's console waiting for arrow-key input, and all it does is restore app.asar - which
-#     the clone-independent step below does directly, without needing Node or the clone to survive.)
+Write-Host 'Orion Quests - uninstalling the auto-update edition...' -ForegroundColor Cyan
 
-# 3. clone-independent restore: for every Discord flavor, if app.asar is a small stub that
-#    points at OUR OrionVencord install and a real _app.asar sits beside it, restore it.
+$runningBefore = @(Get-RunningDiscordFlavors)
+try { Stop-DiscordProcesses } catch { Fail $_.Exception.Message }
+
 $restored = 0; $stuck = 0
-foreach ($f in @('Discord', 'DiscordCanary', 'DiscordPTB')) {
-    Get-ChildItem "$env:LOCALAPPDATA\$f\app-*\resources\app.asar" -ErrorAction SilentlyContinue | ForEach-Object {
-        if ($_.Length -ge 10000) { return }  # multi-MB real asar = not patched, leave it
-        try { $txt = [IO.File]::ReadAllText($_.FullName) } catch { $txt = '' }
-        if ($txt -notlike '*OrionVencord*') { return }  # someone else's Vencord, not ours - leave it
-        $real = Join-Path $_.Directory.FullName '_app.asar'
-        if (Test-Path $real) {
-            Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue
-            Rename-Item $real 'app.asar' -ErrorAction SilentlyContinue
+$patcherPath = Join-Path $InstallDir 'dist\patcher.js'
+foreach ($branch in @('stable', 'canary', 'ptb')) {
+    $root = Get-DiscordRoot -Branch $branch
+    Get-ChildItem (Join-Path $root 'app-*\resources\app.asar') -ErrorAction SilentlyContinue | ForEach-Object {
+        if (-not (Test-AppAsarPointsToPatcher -AppAsar $_.FullName -PatcherPath $patcherPath)) { return }
+        if (Restore-VencordAppAsar -AppAsar $_.FullName -PatcherPath $patcherPath) {
             $restored++
         } else {
             $stuck++
@@ -39,25 +41,30 @@ foreach ($f in @('Discord', 'DiscordCanary', 'DiscordPTB')) {
     }
 }
 
-Write-Host ""
+Write-Host ''
 if ($stuck -gt 0) {
-    Write-Host "Couldn't fully restore $stuck Discord install(s) (the backup app.asar was missing)." -ForegroundColor Red
-    Write-Host "Run the official Vencord installer (vencord.dev/download) and pick Uninstall/Repair." -ForegroundColor Red
+    Write-Host "Couldn't fully restore $stuck Discord install(s)." -ForegroundColor Red
+    Write-Host 'Discord was left closed because at least one Orion patch could not be restored safely.' -ForegroundColor Red
+    Write-Host 'Run the official Vencord installer (vencord.dev/download) and pick Uninstall/Repair before reopening Discord.' -ForegroundColor Red
+    Write-Host "Do NOT delete $InstallDir until Repair/Uninstall has completed successfully." -ForegroundColor Red
+    Write-Host ''
+    try { Read-Host 'Press Enter to close' } catch {}
+    exit 1
 } elseif ($restored -gt 0) {
-    Write-Host "Discord restored to its original state." -ForegroundColor Green
+    Write-Host 'Discord restored to its original state.' -ForegroundColor Green
 } else {
-    Write-Host "Nothing of ours was patched into Discord (already clean)." -ForegroundColor Green
+    Write-Host 'Nothing of ours was patched into Discord (already clean).' -ForegroundColor Green
 }
 
-# 4. reopen whichever flavor is installed
-foreach ($f in @('Discord', 'DiscordCanary', 'DiscordPTB')) {
-    $u = Join-Path $env:LOCALAPPDATA "$f\Update.exe"
-    if (Test-Path $u) { Start-Process $u -ArgumentList '--processStart', "$f.exe" -ErrorAction SilentlyContinue; break }
+$failedReopen = @(Start-DiscordFlavors -Branches $runningBefore)
+if ($failedReopen.Count -gt 0) {
+    Write-Host "Uninstall succeeded, but these Discord clients did not reopen automatically: $($failedReopen -join ', ')." -ForegroundColor Yellow
+    Write-Host 'Start them manually. If one still will not open, run the official Vencord installer and choose Repair.' -ForegroundColor Yellow
 }
 
-Write-Host ""
+Write-Host ''
 Write-Host "You can now delete this folder if you want: $InstallDir" -ForegroundColor DarkGray
-Write-Host "Node.js and Git stay installed. To remove them too (optional):" -ForegroundColor DarkGray
-Write-Host "  winget uninstall OpenJS.NodeJS.LTS   and   winget uninstall Git.Git" -ForegroundColor DarkGray
-Write-Host ""
+Write-Host 'Node.js and Git stay installed. To remove them too (optional):' -ForegroundColor DarkGray
+Write-Host '  winget uninstall OpenJS.NodeJS.LTS   and   winget uninstall Git.Git' -ForegroundColor DarkGray
+Write-Host ''
 try { Read-Host 'Press Enter to close' } catch {}

--- a/tools/orion-devbuild-installer/update.ps1
+++ b/tools/orion-devbuild-installer/update.ps1
@@ -1,9 +1,9 @@
 <#
   Update the Orion Quests auto-update edition.
 
-  Vencord's in-app updater does `git pull` + rebuild but does NOT run `pnpm install` first,
-  so if an upstream update bumps a build dependency the in-Discord rebuild says "Build failed".
-  This script does the full pull + pnpm install + build + restart, which fixes that.
+  Vencord's in-app updater does git pull + rebuild but does not run pnpm install first.
+  This script does the full pull + dependency install + transactional build, then
+  restarts only the Discord flavor(s) that were actually running before the restart.
 #>
 $ErrorActionPreference = 'Stop'
 $env:COREPACK_ENABLE_DOWNLOAD_PROMPT = '0'
@@ -14,7 +14,7 @@ $PluginRepoUrl = 'https://github.com/nyxxbit/discord-quest-completer'
 function Info($m) { Write-Host $m -ForegroundColor Cyan }
 function Good($m) { Write-Host $m -ForegroundColor Green }
 function Warn($m) { Write-Host $m -ForegroundColor Yellow }
-function Fail($m) { Write-Host ""; Write-Host "  ERROR: $m" -ForegroundColor Red; Write-Host ""; try { Read-Host 'Press Enter to exit' } catch {}; exit 1 }
+function Fail($m) { Write-Host ''; Write-Host "  ERROR: $m" -ForegroundColor Red; Write-Host ''; try { Read-Host 'Press Enter to exit' } catch {}; exit 1 }
 function Step([string]$what, [scriptblock]$run) {
     $global:LASTEXITCODE = 0
     $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
@@ -22,71 +22,102 @@ function Step([string]$what, [scriptblock]$run) {
     if ($LASTEXITCODE -ne 0) { Fail "$what failed (exit code $LASTEXITCODE). See output above." }
 }
 
-if (-not (Test-Path (Join-Path $InstallDir '.git'))) { Fail "No OrionVencord install found at $InstallDir. Run INSTALL-autoupdate.cmd first." }
-if (-not (Test-Path $PluginSrc)) { Fail "plugin source folder not found next to this script. Extract the whole zip." }
+$Common = Join-Path $PSScriptRoot 'installer-common.ps1'
+if (-not (Test-Path -LiteralPath $Common -PathType Leaf)) { Fail 'installer-common.ps1 is missing. Re-download/extract the full installer zip.' }
+. $Common
 
-Info "Updating Vencord source..."
+if (-not (Test-Path (Join-Path $InstallDir '.git'))) { Fail "No OrionVencord install found at $InstallDir. Run INSTALL-autoupdate.cmd first." }
+if (-not (Test-Path $PluginSrc)) { Fail 'plugin source folder not found next to this script. Extract the whole zip.' }
+
+Info 'Updating Vencord source...'
 $global:LASTEXITCODE = 0; $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
 git -C $InstallDir pull --ff-only --quiet
 $pc = $LASTEXITCODE; $ErrorActionPreference = $prev
 if ($pc -ne 0) {
-    Warn "  Fast-forward failed - hard-resetting to origin/main..."
+    Warn '  Fast-forward failed - hard-resetting to origin/main...'
     Step 'git fetch' { git -C $InstallDir fetch --depth 1 --quiet origin main }
     Step 'git reset' { git -C $InstallDir reset --hard --quiet FETCH_HEAD }
 }
 
-Info "Updating the plugin..."
+Info 'Updating the plugin...'
 $dest = Join-Path $InstallDir 'src\userplugins\orionQuests'
-
-# Installs from v4.10.4 onward have the plugin as its own git checkout, so pull it. Older
-# installs have a plain copied folder with no .git, and for those the only source of a newer
-# plugin is the zip this script sits in, which is why UPDATE.cmd used to silently keep people
-# on the version they first downloaded. Convert those to a clone on the spot so it is the last
-# time it happens.
-$pulled = $false
+$pluginReady = $false
+$existingCheckoutUsable = $false
 if (Test-Path (Join-Path $dest '.git')) {
+    $existingCheckoutUsable = Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf
+    $updatedFromGit = $false
     $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
-    git -C $dest pull --ff-only --quiet
-    if ($LASTEXITCODE -ne 0) {
-        git -C $dest fetch --depth 1 --quiet origin HEAD
-        git -C $dest reset --hard --quiet FETCH_HEAD
+    try {
+        git -C $dest pull --ff-only --quiet
+        $pullCode = $LASTEXITCODE
+        if ($pullCode -eq 0) {
+            $updatedFromGit = Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf
+        } else {
+            git -C $dest fetch --depth 1 --quiet origin HEAD
+            $fetchCode = $LASTEXITCODE
+            $resetCode = 1
+            if ($fetchCode -eq 0) {
+                git -C $dest reset --hard --quiet FETCH_HEAD
+                $resetCode = $LASTEXITCODE
+            }
+            $updatedFromGit = ($fetchCode -eq 0 -and $resetCode -eq 0 -and (Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf))
+        }
+    } finally {
+        $ErrorActionPreference = $prev
     }
-    $pulled = $LASTEXITCODE -eq 0
-    $ErrorActionPreference = $prev
-    if ($pulled) { Good "  Plugin updated from git." }
+
+    if ($updatedFromGit) {
+        Good '  Plugin updated from git.'
+        $pluginReady = $true
+    } elseif ($existingCheckoutUsable -and (Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf)) {
+        Warn "  Couldn't update the plugin from GitHub; keeping the existing checkout instead of replacing it with the bundled copy."
+        $pluginReady = $true
+    }
 }
 
-if (-not $pulled) {
+if (-not $pluginReady) {
     $prev = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
     if (Test-Path $dest) { Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue }
     git clone --depth 1 --quiet $PluginRepoUrl $dest 2>&1 | Out-Null
-    $ok = ($LASTEXITCODE -eq 0 -and (Test-Path (Join-Path $dest 'index.tsx')))
+    $ok = ($LASTEXITCODE -eq 0 -and (Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf))
     $ErrorActionPreference = $prev
     if ($ok) {
-        Good "  Plugin converted to a git checkout; future updates pull automatically."
+        Good '  Plugin converted to a git checkout; future updates pull automatically.'
+        $pluginReady = $true
     } else {
         Warn "  Couldn't reach GitHub for the plugin, using the copy in this zip instead."
         if (Test-Path $dest) { Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue }
         New-Item -ItemType Directory -Force -Path $dest | Out-Null
         Copy-Item (Join-Path $PluginSrc '*') $dest -Recurse -Force
+        if (-not (Test-Path (Join-Path $dest 'index.tsx') -PathType Leaf)) { Fail 'bundled plugin copy is incomplete (index.tsx is missing).' }
+        $pluginReady = $true
     }
 }
 
 Push-Location $InstallDir
 try {
-    Info "Installing dependencies..."
-    Step 'pnpm install' { corepack pnpm install }
-    Info "Building..."
-    Step 'pnpm build' { corepack pnpm run build }
-    if (-not (Select-String -Path 'dist\renderer.js' -Pattern 'OrionQuests' -SimpleMatch -Quiet)) { Fail "the plugin is missing from the rebuilt Vencord." }
+    try { $pnpm = Get-PnpmInvocation -PackageJsonPath (Join-Path $InstallDir 'package.json') }
+    catch { Fail $_.Exception.Message }
+    Info 'Installing dependencies...'
+    Step 'pnpm install' { Invoke-Pnpm -Invocation $pnpm -Arguments @('install') }
+    Info 'Building transactionally...'
+    try { Invoke-VencordBuildTransactional -InstallDir $InstallDir -Invocation $pnpm -RequiredMarker 'OrionQuests' }
+    catch { Fail $_.Exception.Message }
+    Good 'Build verified. The previous working dist would have been restored automatically on failure.'
 } finally { Pop-Location }
 
-Good "Updated. Restarting Discord..."
-Get-Process Discord, DiscordCanary, DiscordPTB, DiscordSystemHelper -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-Start-Sleep -Seconds 2
-foreach ($f in @('Discord', 'DiscordCanary', 'DiscordPTB')) {
-    $u = Join-Path $env:LOCALAPPDATA "$f\Update.exe"
-    if (Test-Path $u) { Start-Process $u -ArgumentList '--processStart', "$f.exe" -ErrorAction SilentlyContinue; break }
+$runningBefore = @(Get-RunningDiscordFlavors)
+if ($runningBefore.Count -gt 0) {
+    Good "Updated. Restarting: $($runningBefore -join ', ')"
+    try { Stop-DiscordProcesses } catch { Fail $_.Exception.Message }
+    Start-Sleep -Seconds 2
+    $failedReopen = @(Start-DiscordFlavors -Branches $runningBefore)
+    if ($failedReopen.Count -gt 0) {
+        Warn "Update succeeded, but these Discord clients did not reopen automatically: $($failedReopen -join ', ')."
+        Warn 'Start them manually. If one still will not open, run the official Vencord installer and choose Repair.'
+    }
+} else {
+    Good 'Updated. Discord was not running, so it was left closed.'
 }
-Write-Host ""
+Write-Host ''
 try { Read-Host 'Press Enter to close' } catch {}

--- a/tools/orion-vencord-bundle/INSTALL.cmd
+++ b/tools/orion-vencord-bundle/INSTALL.cmd
@@ -10,7 +10,16 @@ echo.
 
 cd /d "%~dp0"
 
-:: 1) Vencord must be installed first
+:: Validate the extracted release before stopping Discord or touching Vencord.
+call :check_dist_complete "%~dp0dist"
+if errorlevel 1 goto :package_incomplete
+if not exist "%~dp0verify-vencord-target.ps1" goto :package_incomplete
+:: %~dp0 always ends in a backslash. Use the normalized current directory when
+:: passing the bundle root through native Windows argv parsing.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0verify-vencord-target.ps1" -Action IsOrionDist -VencordRoot "%CD%" >nul 2>&1
+if errorlevel 1 goto :package_not_orion
+
+:: 1) Vencord must be installed first, and its desktop runtime must be complete.
 if not exist "%APPDATA%\Vencord\dist\" (
     color 0C
     echo  ERROR: You need to install Vencord FIRST.
@@ -22,38 +31,128 @@ if not exist "%APPDATA%\Vencord\dist\" (
     pause
     exit /b 1
 )
+call :check_dist_complete "%APPDATA%\Vencord\dist"
+if errorlevel 1 goto :vencord_incomplete
 
-:: 2) Close Discord before copying. Vencord keeps one shared dist folder for every
-::    branch, so a running Canary or PTB locks the same files Stable would - close
-::    all three, and remember which ones were open so we reopen exactly those.
+:: Verify that the client(s) this installer may operate on actually point at the
+:: shared %APPDATA%\Vencord build. Merely having a Discord folder is not enough.
+set "HAS_STABLE=0"
+set "HAS_CANARY=0"
+set "HAS_PTB=0"
+if exist "%LOCALAPPDATA%\Discord\Update.exe" set "HAS_STABLE=1"
+if exist "%LOCALAPPDATA%\DiscordCanary\Update.exe" set "HAS_CANARY=1"
+if exist "%LOCALAPPDATA%\DiscordPTB\Update.exe" set "HAS_PTB=1"
+set /a INSTALLED_COUNT=HAS_STABLE+HAS_CANARY+HAS_PTB
+
+set "PATCHED_STABLE=0"
+set "PATCHED_CANARY=0"
+set "PATCHED_PTB=0"
+if "%HAS_STABLE%"=="1" call :detect_patched Discord PATCHED_STABLE
+if "%HAS_CANARY%"=="1" call :detect_patched DiscordCanary PATCHED_CANARY
+if "%HAS_PTB%"=="1" call :detect_patched DiscordPTB PATCHED_PTB
+set /a PATCHED_COUNT=PATCHED_STABLE+PATCHED_CANARY+PATCHED_PTB
+if %PATCHED_COUNT% EQU 0 goto :no_patched_client
+
+:: Validation only. The flavor helpers below own stop/reopen tracking; these
+:: variables just prevent replacing the shared dist when a running client points
+:: at some other Vencord checkout (or is not patched at all).
+set "WAS_STABLE=0"
+set "WAS_CANARY=0"
+set "WAS_PTB=0"
+tasklist /FI "IMAGENAME eq Discord.exe" /NH 2>nul | find /I "Discord.exe" >nul
+if not errorlevel 1 set "WAS_STABLE=1"
+tasklist /FI "IMAGENAME eq DiscordCanary.exe" /NH 2>nul | find /I "DiscordCanary.exe" >nul
+if not errorlevel 1 set "WAS_CANARY=1"
+tasklist /FI "IMAGENAME eq DiscordPTB.exe" /NH 2>nul | find /I "DiscordPTB.exe" >nul
+if not errorlevel 1 set "WAS_PTB=1"
+set /a RUNNING_COUNT=WAS_STABLE+WAS_CANARY+WAS_PTB
+if "%WAS_STABLE%"=="1" if not "%PATCHED_STABLE%"=="1" goto :stable_not_patched
+if "%WAS_CANARY%"=="1" if not "%PATCHED_CANARY%"=="1" goto :canary_not_patched
+if "%WAS_PTB%"=="1" if not "%PATCHED_PTB%"=="1" goto :ptb_not_patched
+
+:: When Discord was initially closed, the flavor helper starts the only installed
+:: client if the choice is unambiguous. Validate that fallback target first.
+if %RUNNING_COUNT% EQU 0 if %INSTALLED_COUNT% EQU 1 (
+    if "%HAS_STABLE%"=="1" if not "%PATCHED_STABLE%"=="1" goto :stable_not_patched
+    if "%HAS_CANARY%"=="1" if not "%PATCHED_CANARY%"=="1" goto :canary_not_patched
+    if "%HAS_PTB%"=="1" if not "%PATCHED_PTB%"=="1" goto :ptb_not_patched
+)
+
+:: A saved recovery copy is reusable only while the current dist is still the
+:: Orion standalone bundle. After official Vencord Repair/update, refresh the
+:: backup from that new normal Vencord before replacing the live dist again.
+set "CURRENT_IS_ORION=0"
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0verify-vencord-target.ps1" -Action IsOrionDist -VencordRoot "%APPDATA%\Vencord" >nul 2>&1
+if not errorlevel 1 set "CURRENT_IS_ORION=1"
+set "REFRESH_BACKUP=1"
+if "%CURRENT_IS_ORION%"=="1" set "REFRESH_BACKUP=0"
+if "%REFRESH_BACKUP%"=="0" (
+    if not exist "%APPDATA%\Vencord\dist.orion-backup\" goto :missing_backup
+    call :check_dist_complete "%APPDATA%\Vencord\dist.orion-backup"
+    if errorlevel 1 goto :invalid_backup
+)
+
+:: 2) Close Discord before copying. The flavor helpers own client tracking; the
+:: additional updater/liveness checks here protect the shared Vencord filesystem.
 echo  [1/4] Closing Discord...
 call :stopFlavor Discord
 call :stopFlavor DiscordCanary
 call :stopFlavor DiscordPTB
 taskkill /F /IM DiscordSystemHelper.exe >nul 2>&1
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0verify-vencord-target.ps1" -Action StopDiscordUpdaters >nul 2>&1
+if errorlevel 1 goto :discord_still_running
 ping -n 3 127.0.0.1 >nul
 
-:: 3) Back up the current Vencord build once (so this is undoable), then copy ours in
-echo  [2/4] Copying files into Vencord...
-if not exist "%APPDATA%\Vencord\dist.orion-backup\" (
-    xcopy /Y /Q /E /I "%APPDATA%\Vencord\dist" "%APPDATA%\Vencord\dist.orion-backup" >nul
-)
-xcopy /Y /Q "dist\*" "%APPDATA%\Vencord\dist\" >nul
-if errorlevel 1 (
-    color 0C
-    echo.
-    echo  ERROR copying the files. Make sure you extracted the whole zip
-    echo  ^(the "dist" folder has to sit right next to this .cmd^).
-    pause
-    exit /b 1
-)
+tasklist /FI "IMAGENAME eq Discord.exe" /NH 2>nul | find /I "Discord.exe" >nul
+if not errorlevel 1 goto :discord_still_running
+tasklist /FI "IMAGENAME eq DiscordCanary.exe" /NH 2>nul | find /I "DiscordCanary.exe" >nul
+if not errorlevel 1 goto :discord_still_running
+tasklist /FI "IMAGENAME eq DiscordPTB.exe" /NH 2>nul | find /I "DiscordPTB.exe" >nul
+if not errorlevel 1 goto :discord_still_running
+tasklist /FI "IMAGENAME eq DiscordSystemHelper.exe" /NH 2>nul | find /I "DiscordSystemHelper.exe" >nul
+if not errorlevel 1 goto :discord_still_running
 
-:: 4) Reopen whatever we closed
+:: 3) Build/refresh the recovery copy beside the current one, verify it, then swap
+:: it into place. A failed refresh must never destroy the only usable backup.
+echo  [2/4] Copying files into Vencord...
+if "%REFRESH_BACKUP%"=="0" goto :backup_ready
+set "NEW_BACKUP=%APPDATA%\Vencord\dist.orion-backup.new"
+set "OLD_BACKUP=%APPDATA%\Vencord\dist.orion-backup.old"
+if exist "%NEW_BACKUP%\" rmdir /S /Q "%NEW_BACKUP%" >nul 2>&1
+if exist "%OLD_BACKUP%\" rmdir /S /Q "%OLD_BACKUP%" >nul 2>&1
+xcopy /Y /Q /E /I "%APPDATA%\Vencord\dist" "%NEW_BACKUP%" >nul
+if errorlevel 1 goto :backup_failed
+call :check_dist_complete "%NEW_BACKUP%"
+if errorlevel 1 goto :backup_failed
+if exist "%APPDATA%\Vencord\dist.orion-backup\" move /Y "%APPDATA%\Vencord\dist.orion-backup" "%OLD_BACKUP%" >nul
+if errorlevel 1 if exist "%APPDATA%\Vencord\dist.orion-backup\" goto :backup_failed
+move /Y "%NEW_BACKUP%" "%APPDATA%\Vencord\dist.orion-backup" >nul
+if errorlevel 1 goto :backup_swap_failed
+call :check_dist_complete "%APPDATA%\Vencord\dist.orion-backup"
+if errorlevel 1 goto :backup_swap_failed
+if exist "%OLD_BACKUP%\" rmdir /S /Q "%OLD_BACKUP%" >nul 2>&1
+
+:backup_ready
+:: Replace the whole dist instead of overlaying files from two builds. Any copy or
+:: semantic verification failure restores the checked recovery copy before reopen.
+rmdir /S /Q "%APPDATA%\Vencord\dist" >nul 2>&1
+if exist "%APPDATA%\Vencord\dist\" goto :copy_failed
+mkdir "%APPDATA%\Vencord\dist" >nul 2>&1
+if errorlevel 1 goto :copy_failed
+xcopy /Y /Q /E /I "%~dp0dist\*" "%APPDATA%\Vencord\dist\" >nul
+if errorlevel 1 goto :copy_failed
+call :check_dist_complete "%APPDATA%\Vencord\dist"
+if errorlevel 1 goto :copy_failed
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0verify-vencord-target.ps1" -Action IsOrionDist -VencordRoot "%APPDATA%\Vencord" >nul 2>&1
+if errorlevel 1 goto :copy_failed
+
+:: 4) Reopen whatever the flavor helpers recorded, or their single-install fallback.
 echo  [3/4] Reopening Discord...
 call :startFlavor Discord
 call :startFlavor DiscordCanary
 call :startFlavor DiscordPTB
-if not defined ORION_STARTED call :startFallback
+if defined ORION_REOPEN_BLOCKED echo        A Discord build we closed could not be reopened - open it yourself.
+if not defined ORION_STARTED if not defined ORION_REOPEN_BLOCKED call :startFallback
 ping -n 5 127.0.0.1 >nul
 
 echo  [4/4] Done!
@@ -77,8 +176,35 @@ echo.
 pause
 exit /b 0
 
+:: ── hardening helpers ──────────────────────────────────────────
 
-:: ── helpers ───────────────────────────────────────────────────
+:check_dist_complete
+if not exist "%~1\patcher.js" exit /b 1
+if not exist "%~1\preload.js" exit /b 1
+if not exist "%~1\renderer.js" exit /b 1
+if not exist "%~1\renderer.css" exit /b 1
+for %%F in ("%~1\patcher.js") do if %%~zF LEQ 0 exit /b 1
+for %%F in ("%~1\preload.js") do if %%~zF LEQ 0 exit /b 1
+for %%F in ("%~1\renderer.js") do if %%~zF LEQ 0 exit /b 1
+for %%F in ("%~1\renderer.css") do if %%~zF LEQ 0 exit /b 1
+exit /b 0
+
+:check_vencord_target
+set "%~2=0"
+if not exist "%~1" exit /b 0
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0verify-vencord-target.ps1" -AppAsar "%~1" -VencordRoot "%APPDATA%\Vencord" >nul 2>&1
+if not errorlevel 1 set "%~2=1"
+exit /b 0
+
+:detect_patched
+set "%~2=0"
+set "ORION_ACTIVE_APP="
+for /f "delims=" %%D in ('dir /b /ad /o:n "%LOCALAPPDATA%\%~1\app-*" 2^>nul') do if exist "%LOCALAPPDATA%\%~1\%%D\resources\" set "ORION_ACTIVE_APP=%%D"
+if not defined ORION_ACTIVE_APP exit /b 0
+call :check_vencord_target "%LOCALAPPDATA%\%~1\%ORION_ACTIVE_APP%\resources\app.asar" %~2
+exit /b 0
+
+:: ── flavor helpers ──────────────────────────────────────────────
 
 :: Close one Discord build if it is running, and remember that it was.
 :stopFlavor
@@ -89,10 +215,15 @@ taskkill /F /IM %~1.exe >nul 2>&1
 goto :eof
 
 :: Reopen one build, but only the ones we closed ourselves - a Stable-only user
-:: should not end up with Canary launched at them.
+:: should not end up with Canary launched at them. If its updater disappeared
+:: after preflight, remember that this flavor cannot be put back and suppress any
+:: fallback that would open a different Discord build instead.
 :startFlavor
 if not defined ORION_WASRUNNING_%~1 goto :eof
-if not exist "%LOCALAPPDATA%\%~1\Update.exe" goto :eof
+if not exist "%LOCALAPPDATA%\%~1\Update.exe" (
+    set "ORION_REOPEN_BLOCKED=1"
+    goto :eof
+)
 start "" "%LOCALAPPDATA%\%~1\Update.exe" --processStart %~1.exe
 set "ORION_STARTED=1"
 goto :eof
@@ -114,3 +245,140 @@ if "%ORION_COUNT%"=="1" (
 )
 echo        Discord was not running, so it was not reopened - open it yourself.
 goto :eof
+
+:: ── failure paths ───────────────────────────────────────────────
+
+:package_incomplete
+color 0C
+echo  ERROR: The installer package is incomplete.
+echo  Extract the complete release zip. The dist folder must contain non-empty:
+echo    patcher.js, preload.js, renderer.js, renderer.css
+echo  and verify-vencord-target.ps1 must be next to INSTALL.cmd.
+echo.
+pause
+exit /b 1
+
+:package_not_orion
+color 0C
+echo  ERROR: The bundled dist is not a valid Orion standalone Vencord build.
+echo  Re-extract the official release zip instead of mixing files from builds.
+echo.
+pause
+exit /b 1
+
+:vencord_incomplete
+color 0C
+echo  ERROR: Your current Vencord installation is incomplete.
+echo  Run the official Vencord installer and choose Repair, then retry.
+echo.
+pause
+exit /b 1
+
+:no_patched_client
+color 0C
+echo  ERROR: No installed Discord client points at %%APPDATA%%\Vencord.
+echo  Install/Repair Vencord for the Discord client you use, then retry.
+echo.
+pause
+exit /b 1
+
+:stable_not_patched
+color 0C
+echo  ERROR: Running/fallback Discord Stable does not point at %%APPDATA%%\Vencord.
+goto :patch_help
+
+:canary_not_patched
+color 0C
+echo  ERROR: Running/fallback Discord Canary does not point at %%APPDATA%%\Vencord.
+goto :patch_help
+
+:ptb_not_patched
+color 0C
+echo  ERROR: Running/fallback Discord PTB does not point at %%APPDATA%%\Vencord.
+
+:patch_help
+echo  Run the official Vencord installer for that client, then retry.
+echo.
+pause
+exit /b 1
+
+:missing_backup
+color 0C
+echo  ERROR: The Orion bundle is active, but its original Vencord backup is missing.
+echo  Run the official Vencord installer and choose Repair before reinstalling Orion.
+echo.
+pause
+exit /b 1
+
+:invalid_backup
+color 0C
+echo  ERROR: The Orion bundle is active, but dist.orion-backup is incomplete.
+echo  Run the official Vencord installer and choose Repair before reinstalling Orion.
+echo.
+pause
+exit /b 1
+
+:discord_still_running
+call :startFlavor Discord
+call :startFlavor DiscordCanary
+call :startFlavor DiscordPTB
+color 0C
+echo.
+echo  ERROR: Discord or its updater did not fully close. No Vencord files were changed.
+echo  Close Discord manually, wait for any client update to finish, and retry.
+echo.
+pause
+exit /b 1
+
+:backup_failed
+if defined NEW_BACKUP if exist "%NEW_BACKUP%\" rmdir /S /Q "%NEW_BACKUP%" >nul 2>&1
+if defined OLD_BACKUP if exist "%OLD_BACKUP%\" if not exist "%APPDATA%\Vencord\dist.orion-backup\" move /Y "%OLD_BACKUP%" "%APPDATA%\Vencord\dist.orion-backup" >nul
+call :startFlavor Discord
+call :startFlavor DiscordCanary
+call :startFlavor DiscordPTB
+color 0C
+echo.
+echo  ERROR: Could not create a complete Vencord backup. No Orion files were copied.
+echo  Check free disk space and permissions, then retry.
+echo.
+pause
+exit /b 1
+
+:backup_swap_failed
+if exist "%APPDATA%\Vencord\dist.orion-backup\" rmdir /S /Q "%APPDATA%\Vencord\dist.orion-backup" >nul 2>&1
+if defined OLD_BACKUP if exist "%OLD_BACKUP%\" move /Y "%OLD_BACKUP%" "%APPDATA%\Vencord\dist.orion-backup" >nul
+if not exist "%APPDATA%\Vencord\dist.orion-backup\" goto :restore_failed
+call :check_dist_complete "%APPDATA%\Vencord\dist.orion-backup"
+if errorlevel 1 goto :restore_failed
+goto :backup_failed
+
+:copy_failed
+color 0C
+echo.
+echo  ERROR: Copying the Orion Vencord build failed. Restoring previous Vencord...
+rmdir /S /Q "%APPDATA%\Vencord\dist" >nul 2>&1
+mkdir "%APPDATA%\Vencord\dist" >nul 2>&1
+xcopy /Y /Q /E /I "%APPDATA%\Vencord\dist.orion-backup\*" "%APPDATA%\Vencord\dist\" >nul
+if errorlevel 1 goto :restore_failed
+call :check_dist_complete "%APPDATA%\Vencord\dist"
+if errorlevel 1 goto :restore_failed
+call :startFlavor Discord
+call :startFlavor DiscordCanary
+call :startFlavor DiscordPTB
+if defined ORION_REOPEN_BLOCKED echo  A Discord build we closed could not be reopened - open it yourself.
+if not defined ORION_STARTED if not defined ORION_REOPEN_BLOCKED call :startFallback
+echo  Previous Vencord restored. Check disk space/permissions and retry.
+echo.
+pause
+exit /b 1
+
+:restore_failed
+color 0C
+echo.
+echo  ERROR: Automatic rollback also failed.
+echo  Leave Discord closed. Your recovery copy remains at:
+echo    %%APPDATA%%\Vencord\dist.orion-backup
+echo  Run the official Vencord installer and choose Repair before reopening Discord.
+echo.
+pause
+exit /b 1

--- a/tools/orion-vencord-bundle/verify-vencord-target.ps1
+++ b/tools/orion-vencord-bundle/verify-vencord-target.ps1
@@ -1,0 +1,79 @@
+param(
+    [ValidateSet('VerifyTarget', 'IsOrionDist', 'StopDiscordUpdaters')][string]$Action = 'VerifyTarget',
+    [string]$AppAsar,
+    [string]$VencordRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Test-IsUnderRoot([string]$Path, [string]$Root) {
+    if ([string]::IsNullOrWhiteSpace($Path) -or [string]::IsNullOrWhiteSpace($Root)) { return $false }
+    try {
+        $candidate = [IO.Path]::GetFullPath($Path)
+        $fullRoot = [IO.Path]::GetFullPath($Root).TrimEnd('\', '/')
+        $prefix = $fullRoot + [IO.Path]::DirectorySeparatorChar
+        return $candidate.Equals((Join-Path $fullRoot 'Update.exe'), [StringComparison]::OrdinalIgnoreCase) -or
+            $candidate.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)
+    } catch {
+        return $false
+    }
+}
+
+try {
+    if ($Action -eq 'StopDiscordUpdaters') {
+        $roots = @('Discord', 'DiscordCanary', 'DiscordPTB') | ForEach-Object { Join-Path $env:LOCALAPPDATA $_ }
+        $deadline = (Get-Date).AddSeconds(15)
+        do {
+            $updaters = @(Get-Process Update -ErrorAction SilentlyContinue | Where-Object {
+                $path = $null
+                try { $path = $_.Path } catch {}
+                $matched = $false
+                foreach ($root in $roots) {
+                    if (Test-IsUnderRoot -Path $path -Root $root) { $matched = $true; break }
+                }
+                $matched
+            })
+            if ($updaters.Count -eq 0) { exit 0 }
+            $updaters | Stop-Process -Force -ErrorAction SilentlyContinue
+            Start-Sleep -Milliseconds 500
+        } while ((Get-Date) -lt $deadline)
+
+        $remaining = @(Get-Process Update -ErrorAction SilentlyContinue | Where-Object {
+            $path = $null
+            try { $path = $_.Path } catch {}
+            foreach ($root in $roots) {
+                if (Test-IsUnderRoot -Path $path -Root $root) { return $true }
+            }
+            return $false
+        })
+        if ($remaining.Count -eq 0) { exit 0 }
+        exit 1
+    }
+
+    if ($Action -eq 'IsOrionDist') {
+        if ([string]::IsNullOrWhiteSpace($VencordRoot)) { exit 1 }
+        $dist = Join-Path $VencordRoot 'dist'
+        foreach ($name in @('patcher.js', 'preload.js', 'renderer.js', 'renderer.css')) {
+            if (-not (Test-Path -LiteralPath (Join-Path $dist $name) -PathType Leaf)) { exit 1 }
+        }
+        $patcher = Join-Path $dist 'patcher.js'
+        $renderer = Join-Path $dist 'renderer.js'
+        $isStandaloneFrozen = (Select-String -LiteralPath $patcher -Pattern 'Standalone: true' -SimpleMatch -Quiet) -and
+            (Select-String -LiteralPath $patcher -Pattern 'Updater Disabled: true' -SimpleMatch -Quiet)
+        $hasOrion = Select-String -LiteralPath $renderer -Pattern 'OrionQuests' -SimpleMatch -Quiet
+        if ($isStandaloneFrozen -and $hasOrion) { exit 0 }
+        exit 1
+    }
+
+    if ([string]::IsNullOrWhiteSpace($AppAsar) -or [string]::IsNullOrWhiteSpace($VencordRoot)) { exit 1 }
+    if (-not (Test-Path -LiteralPath $AppAsar -PathType Leaf)) { exit 1 }
+    $text = [IO.File]::ReadAllText($AppAsar)
+    $expected = [IO.Path]::GetFullPath((Join-Path $VencordRoot 'dist\patcher.js'))
+    # Vencord Installer JSON-marshals the require() path inside app.asar. Match the
+    # complete quoted path so another checkout whose path merely shares our prefix
+    # cannot be mistaken for the shared %APPDATA%\Vencord build.
+    $serializedExpected = '"' + $expected.Replace('\', '\\') + '"'
+    if ($text.IndexOf($serializedExpected, [StringComparison]::OrdinalIgnoreCase) -ge 0) { exit 0 }
+} catch {}
+
+exit 1

--- a/tools/package-release.ps1
+++ b/tools/package-release.ps1
@@ -12,15 +12,22 @@
       (issue #39); --standalone alone is worse, its HTTP updater silently reverts the dist to
       vanilla and deletes the plugin. Only both flags together are safe for a copy-in-place
       install, and the only way to tell is the banner at the top of dist/patcher.js.
+    - the bundle must come from a clean Vencord source tree whose src/userplugins contains
+      no userplugin source except orionQuests. This is deliberately stricter than trying to
+      predict Vencord's target filtering: renderer plugin discovery and native discovery are
+      separate build paths, so absence of foreign source is the simple provenance invariant.
     - the devbuild installer ships a copy of the plugin sources, which moved to the repo root
       in v4.9.7 so UserpluginInstaller can clone the repo directly (#42)
 
-  Run from anywhere. Does not build Vencord: point -BundleDist at a dist/ you already built
-  with `pnpm build --standalone --disable-updater`, or skip the bundle with -SkipBundle.
+  Run from anywhere. For a bundle, -BundleDist must point at the dist directory inside the
+  clean Vencord source tree that produced it. -BundleSource may name that source root
+  explicitly; otherwise it is inferred as the parent of -BundleDist. Skip the bundle with
+  -SkipBundle.
 #>
 [CmdletBinding()]
 param(
     [string] $BundleDist,
+    [string] $BundleSource,
     [switch] $SkipBundle
 )
 
@@ -42,13 +49,13 @@ Info "Version from index.js: $Version"
 $checks = @(
     # The README carries the version in its badge only. It used to repeat it in the headline
     # too, until that line went with the rewrite that pulled the marketing voice out.
-    @{ File = 'README.md';                              Pattern = "badge/$Version-5865F2" }
-    @{ File = 'docs/VENCORD-PLUGIN.md';                 Pattern = "in sync with userscript $Version" }
-    @{ File = 'docs/ARCHITECTURE.md';                   Pattern = "Last reviewed against .index\.js. \*\*$Version\*\*" }
+    @{ File = 'README.md';                                Pattern = "badge/$Version-5865F2" }
+    @{ File = 'docs/VENCORD-PLUGIN.md';                   Pattern = "in sync with userscript $Version" }
+    @{ File = 'docs/ARCHITECTURE.md';                     Pattern = "Last reviewed against .index\.js. \*\*$Version\*\*" }
     @{ File = 'tools/orion-devbuild-installer/README.txt'; Pattern = "Version: $Version" }
     # The plugin carries its own version since v4.10.7. Before that a plugin user could not say
     # which build a bug report came from, and neither could anyone triaging it (issue #66).
-    @{ File = 'index.tsx';                              Pattern = "PLUGIN_VERSION = ""$Version""" }
+    @{ File = 'index.tsx';                                Pattern = "PLUGIN_VERSION = ""$Version""" }
 )
 $drift = @()
 foreach ($c in $checks) {
@@ -78,42 +85,83 @@ $staged = (Get-ChildItem $stage -File).Count
 if ($staged -lt 9) { Die "only $staged plugin files staged, expected the full set" }
 Good "$staged files staged"
 
-# ---- 3. the Tier 1 bundle must be a standalone, updater-disabled build -----------
+# ---- 3. the Tier 1 bundle must be a clean standalone, updater-disabled build -----
 if (-not $SkipBundle) {
+    if ([string]::IsNullOrWhiteSpace($BundleDist)) {
+        Die "bundle packaging requires -BundleDist <clean Vencord clone>\dist so the source userplugin set can be verified"
+    }
+
+    try { $bundleDistFull = (Resolve-Path -LiteralPath $BundleDist -ErrorAction Stop).Path }
+    catch { Die "BundleDist '$BundleDist' does not exist" }
+
+    if ($BundleSource) {
+        try { $sourceRoot = (Resolve-Path -LiteralPath $BundleSource -ErrorAction Stop).Path }
+        catch { Die "BundleSource '$BundleSource' does not exist" }
+    } else {
+        $sourceRoot = Split-Path -Parent $bundleDistFull
+    }
+
+    $expectedDist = [IO.Path]::GetFullPath((Join-Path $sourceRoot 'dist')).TrimEnd('\', '/')
+    $actualDist = [IO.Path]::GetFullPath($bundleDistFull).TrimEnd('\', '/')
+    if (-not $actualDist.Equals($expectedDist, [StringComparison]::OrdinalIgnoreCase)) {
+        Die "BundleDist must be the dist directory inside BundleSource. Expected '$expectedDist', got '$actualDist'."
+    }
+
+    $userplugins = Join-Path $sourceRoot 'src\userplugins'
+    $orionEntry = Join-Path $userplugins 'orionQuests\index.tsx'
+    if (-not (Test-Path -LiteralPath $orionEntry -PathType Leaf)) {
+        Die "clean bundle source is missing src\userplugins\orionQuests\index.tsx"
+    }
+
+    # This is a source-provenance rule, not a prediction that every extra entry would
+    # necessarily reach every output. Renderer discovery skips some names, but Vencord's
+    # native discovery scans every userplugin entry for native.ts. Therefore do not exempt
+    # '_' or '.' names here: a hidden/disabled-looking directory can still affect patcher.js.
+    # index.ts is the only non-plugin infrastructure file Vencord's renderer explicitly skips;
+    # as a file it cannot itself contain <entry>/native.ts, so it is safe to permit.
+    $extraUserPluginSources = @()
+    if (Test-Path -LiteralPath $userplugins -PathType Container) {
+        $extraUserPluginSources = @(Get-ChildItem -LiteralPath $userplugins -Force | Where-Object {
+            if ($_.Name -eq 'orionQuests') { $false }
+            elseif (-not $_.PSIsContainer -and $_.Name -eq 'index.ts') { $false }
+            else { $true }
+        })
+    }
+    if ($extraUserPluginSources.Count -gt 0) {
+        $names = $extraUserPluginSources.Name -join ', '
+        Die "bundle source is not clean; additional Vencord userplugin entries are present: $names. Use a clean clone containing only src\userplugins\orionQuests (plus an optional root index.ts infrastructure file) before building."
+    }
+    Good "bundle source provenance is clean: only orionQuests userplugin source is present"
+
     $bundleDir = Join-Path $Tools 'orion-vencord-bundle'
     $dist = Join-Path $bundleDir 'dist'
-    if ($BundleDist) {
-        Info "Refreshing the bundle dist from $BundleDist ..."
-        if (-not (Test-Path (Join-Path $BundleDist 'patcher.js'))) { Die "$BundleDist has no patcher.js" }
-        if (Test-Path $dist) { Remove-Item $dist -Recurse -Force }
-        New-Item -ItemType Directory -Force -Path $dist | Out-Null
-        Get-ChildItem $BundleDist -File | Where-Object { $_.Name -notlike '*.map' } | ForEach-Object { Copy-Item $_.FullName $dist }
+    $requiredDesktopFiles = @('patcher.js', 'preload.js', 'renderer.js', 'renderer.css')
+
+    Info "Refreshing the bundle dist from $bundleDistFull ..."
+    foreach ($name in $requiredDesktopFiles) {
+        $candidate = Join-Path $bundleDistFull $name
+        if (-not (Test-Path -LiteralPath $candidate -PathType Leaf) -or (Get-Item -LiteralPath $candidate).Length -le 0) {
+            Die "$bundleDistFull is incomplete: required Discord Vencord runtime file '$name' is missing or empty"
+        }
     }
-    if (-not (Test-Path (Join-Path $dist 'patcher.js'))) { Die "no bundle dist. Build it with 'pnpm build --standalone --disable-updater' and pass -BundleDist <clone>\dist" }
+    if (Test-Path $dist) { Remove-Item $dist -Recurse -Force }
+    New-Item -ItemType Directory -Force -Path $dist | Out-Null
+    Get-ChildItem $bundleDistFull -File | Where-Object { $_.Name -notlike '*.map' } | ForEach-Object { Copy-Item $_.FullName $dist }
+
+    foreach ($name in $requiredDesktopFiles) {
+        $candidate = Join-Path $dist $name
+        if (-not (Test-Path -LiteralPath $candidate -PathType Leaf) -or (Get-Item -LiteralPath $candidate).Length -le 0) {
+            Die "bundle dist is incomplete: '$name' is missing or empty. Build Vencord with 'pnpm build --standalone --disable-updater' and pass the complete dist with -BundleDist."
+        }
+    }
 
     # the banner is a few `//` lines and the order isn't fixed (Standalone, Platform,
     # Updater Disabled), so read past all of them rather than assuming a line count
     $banner = (Get-Content (Join-Path $dist 'patcher.js') -TotalCount 10) -join "`n"
-    if ($banner -notmatch 'Standalone:\s*true')      { Die "bundle dist is NOT a --standalone build. It would break Vencord's updater (#39)." }
-    if ($banner -notmatch 'Updater Disabled:\s*true'){ Die "bundle dist is NOT --disable-updater. Its HTTP updater would revert the dist to vanilla and delete the plugin (#39)." }
+    if ($banner -notmatch 'Standalone:\s*true')       { Die "bundle dist is NOT a --standalone build. It would break Vencord's updater (#39)." }
+    if ($banner -notmatch 'Updater Disabled:\s*true') { Die "bundle dist is NOT --disable-updater. Its HTTP updater would revert the dist to vanilla and delete the plugin (#39)." }
     if (-not (Select-String -Path (Join-Path $dist 'renderer.js') -Pattern 'OrionQuests' -SimpleMatch -Quiet)) { Die "the plugin is not in the bundle dist" }
-
-    # The bundle is built from whatever userplugins the source clone happens to hold, so any
-    # third-party plugin sitting beside ours gets compiled into the dist and shipped inside an
-    # artifact we distribute under our own licence. That happened in v4.9.9 and v4.10.0, which
-    # went out carrying a GPL-3.0 plugin. Refuse rather than trust the clone to be clean.
-    $foreign = @(
-        @{ Name = 'QuestUI'; Marker = 'renderQuestButtonTopBar' }
-    )
-    $renderers = Get-ChildItem $dist -File | Where-Object { $_.Name -match '^(vencordDesktop)?[Rr]enderer\.js$' }
-    foreach ($f in $foreign) {
-        foreach ($r in $renderers) {
-            if (Select-String -Path $r.FullName -Pattern $f.Marker -SimpleMatch -Quiet) {
-                Die "$($f.Name) is compiled into $($r.Name). Move it out of <clone>\src\userplugins before building the bundle dist; we must not redistribute someone else's plugin inside ours."
-            }
-        }
-    }
-    Good "bundle dist is standalone + updater-disabled, contains our plugin and no foreign one"
+    Good "bundle dist is complete, standalone + updater-disabled, contains OrionQuests, and came from the required clean source tree"
 
     # The bundle is a compiled Vencord, which is GPL-3.0-or-later, so conveying it means
     # shipping the licence text and saying where the corresponding source is. That was missing

--- a/tools/tests/installer-regression.ps1
+++ b/tools/tests/installer-regression.ps1
@@ -1,0 +1,241 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$DevbuildDir = Join-Path $RepoRoot 'tools\orion-devbuild-installer'
+$BundleDir = Join-Path $RepoRoot 'tools\orion-vencord-bundle'
+$Helper = Join-Path $DevbuildDir 'installer-common.ps1'
+$BundleVerifier = Join-Path $BundleDir 'verify-vencord-target.ps1'
+$Workflow = Join-Path $RepoRoot '.github\workflows\installer.yml'
+$Packager = Join-Path $RepoRoot 'tools\package-release.ps1'
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw $Message }
+}
+function Assert-False([bool]$Condition, [string]$Message) {
+    if ($Condition) { throw $Message }
+}
+function Assert-Equal($Actual, $Expected, [string]$Message) {
+    if ($Actual -ne $Expected) { throw "$Message`nExpected: $Expected`nActual:   $Actual" }
+}
+function Assert-SequenceEqual([object[]]$Actual, [object[]]$Expected, [string]$Message) {
+    $a = @($Actual); $e = @($Expected)
+    if ($a.Count -ne $e.Count) { throw "$Message`nExpected: $($e -join ', ')`nActual:   $($a -join ', ')" }
+    for ($i = 0; $i -lt $e.Count; $i++) {
+        if ($a[$i] -ne $e[$i]) { throw "$Message`nExpected: $($e -join ', ')`nActual:   $($a -join ', ')" }
+    }
+}
+function Assert-Throws([scriptblock]$Action, [string]$Message) {
+    $threw = $false
+    try { & $Action } catch { $threw = $true }
+    if (-not $threw) { throw $Message }
+}
+
+Assert-True (Test-Path $Helper) 'installer-common.ps1 is required so install/update/uninstall share one tested Discord/toolchain implementation.'
+. $Helper
+
+Assert-Equal (Resolve-DiscordFlavor -Installed @('stable', 'canary') -Running @('canary')) 'canary' 'Running Canary must win when Stable is also installed.'
+Assert-Equal (Resolve-DiscordFlavor -Installed @('stable', 'ptb') -Running @('ptb')) 'ptb' 'Running PTB must win when Stable is also installed.'
+Assert-Equal (Resolve-DiscordFlavor -Installed @('canary') -Running @()) 'canary' 'A single installed flavor is unambiguous even when Discord is closed.'
+Assert-Equal (Resolve-DiscordFlavor -Installed @('stable', 'canary') -Running @() -PreferredBranch 'canary') 'canary' 'An explicit installed branch must be honored.'
+Assert-Throws { Resolve-DiscordFlavor -Installed @('stable', 'canary') -Running @() } 'Multiple installed flavors with none running must not silently fall back to Stable.'
+Assert-Throws { Resolve-DiscordFlavor -Installed @('stable', 'canary') -Running @('stable', 'canary') } 'Multiple running flavors are ambiguous and must not be guessed.'
+
+Assert-SequenceEqual (Get-DiscordReopenSet -RunningBefore @('canary') -TargetBranch 'stable') @('canary', 'stable') 'Patch Stable while Canary was running must reopen both Canary and the patched Stable target.'
+Assert-SequenceEqual (Get-DiscordReopenSet -RunningBefore @('canary') -TargetBranch 'canary') @('canary') 'The target must not be duplicated in the reopen set.'
+Assert-SequenceEqual (Get-DiscordReopenSet -RunningBefore @() -TargetBranch 'ptb') @('ptb') 'A closed client install must reopen the target that was patched.'
+
+$roots = @('C:\Users\ci\AppData\Local\Discord','C:\Users\ci\AppData\Local\DiscordCanary','C:\Users\ci\AppData\Local\DiscordPTB')
+Assert-True (Test-IsDiscordUpdaterPath -Path 'C:\Users\ci\AppData\Local\DiscordCanary\Update.exe' -DiscordRoots $roots) 'Discord Canary updater must be recognized as Discord-owned.'
+Assert-False (Test-IsDiscordUpdaterPath -Path 'C:\Program Files\SomeOtherApp\Update.exe' -DiscordRoots $roots) 'An unrelated Update.exe must never be classified as Discord-owned.'
+
+$temp = Join-Path ([IO.Path]::GetTempPath()) ("orion-installer-test-" + [guid]::NewGuid().ToString('N'))
+try {
+    $discordRoot = Join-Path $temp 'DiscordCanary'
+    $oldResources = Join-Path $discordRoot 'app-1.0.100\resources'
+    $newResources = Join-Path $discordRoot 'app-1.0.200\resources'
+    New-Item -ItemType Directory -Force -Path $oldResources, $newResources | Out-Null
+    (Get-Item (Split-Path $oldResources -Parent)).LastWriteTime = (Get-Date).AddMinutes(10)
+    (Get-Item (Split-Path $newResources -Parent)).LastWriteTime = (Get-Date).AddMinutes(-10)
+    Assert-Equal (Select-VencordDiscordResourcesPath -DiscordRoot $discordRoot) $newResources 'Verification must select the same app-* target rule as Vencord Installer.'
+} finally { Remove-Item $temp -Recurse -Force -ErrorAction SilentlyContinue }
+
+$temp = Join-Path ([IO.Path]::GetTempPath()) ("orion-asar-test-" + [guid]::NewGuid().ToString('N'))
+try {
+    $resources = Join-Path $temp 'resources'
+    New-Item -ItemType Directory -Force -Path $resources | Out-Null
+    $asar = Join-Path $resources 'app.asar'
+    $backup = Join-Path $resources '_app.asar'
+    $ours = Join-Path $temp 'OrionVencord\dist\patcher.js'
+    $other = Join-Path $temp 'OtherVencord\dist\patcher.js'
+    $collision = $ours + '.backup'
+
+    $serializedCollision = ([IO.Path]::GetFullPath($collision)).Replace('\', '\\')
+    Set-Content -LiteralPath $asar -Value ("require(`"$serializedCollision`")") -Encoding UTF8
+    Assert-False (Test-AppAsarPointsToPatcher -AppAsar $asar -PatcherPath $ours) 'A path whose text merely starts with our patcher path must be rejected.'
+
+    $serializedOurs = ([IO.Path]::GetFullPath($ours)).Replace('\', '\\')
+    Set-Content -LiteralPath $asar -Value ("require(`"$serializedOurs`")") -Encoding UTF8
+    Assert-True (Test-AppAsarPointsToPatcher -AppAsar $asar -PatcherPath $ours) 'Exact OrionVencord patcher path must be accepted.'
+    Assert-False (Test-AppAsarPointsToPatcher -AppAsar $asar -PatcherPath $other) 'A different checkout must not be treated as ours.'
+
+    Set-Content -LiteralPath $backup -Value 'original discord app.asar' -Encoding UTF8
+    Assert-True (Restore-VencordAppAsar -AppAsar $asar -PatcherPath $ours) 'Restore helper must replace the Orion stub with _app.asar.'
+    Assert-True (Test-Path -LiteralPath $asar -PathType Leaf) 'Restore helper must leave app.asar present.'
+    Assert-False (Test-Path -LiteralPath $backup -PathType Leaf) 'Successful restore must consume _app.asar.'
+    Assert-False (Test-AppAsarPointsToPatcher -AppAsar $asar -PatcherPath $ours) 'Restored app.asar must no longer point at OrionVencord.'
+
+    Set-Content -LiteralPath $asar -Value ("require(`"$serializedOurs`")") -Encoding UTF8
+    Assert-False (Restore-VencordAppAsar -AppAsar $asar -PatcherPath $ours) 'Restore must fail when _app.asar is missing instead of reporting success.'
+    Assert-True (Test-AppAsarPointsToPatcher -AppAsar $asar -PatcherPath $ours) 'A failed restore with no backup must leave the current Orion stub untouched.'
+} finally { Remove-Item $temp -Recurse -Force -ErrorAction SilentlyContinue }
+
+$tempPackage = Join-Path ([IO.Path]::GetTempPath()) ("orion-package-" + [guid]::NewGuid().ToString('N') + '.json')
+try {
+    '{"packageManager":"pnpm@11.9.0","engines":{"node":">=22"}}' | Set-Content -Path $tempPackage -Encoding UTF8
+    $pnpm = Get-PnpmInvocation -PackageJsonPath $tempPackage
+    Assert-True (-not [string]::IsNullOrWhiteSpace($pnpm.Command)) 'A pnpm command must be resolved.'
+    Assert-True ($null -ne (Get-Command $pnpm.Command -ErrorAction SilentlyContinue)) "Resolved pnpm launcher '$($pnpm.Command)' must exist on PATH."
+    $nodeMajor = [int]((node -v).TrimStart('v').Split('.')[0])
+    if ($nodeMajor -ge 25) {
+        Assert-True ($null -ne (Get-Command npx -ErrorAction SilentlyContinue)) 'Node 25 fallback requires npx from the normal Node distribution.'
+        $actualPnpmVersion = (& npx --yes pnpm@11.9.0 --version | Select-Object -Last 1).Trim()
+        Assert-Equal $actualPnpmVersion '11.9.0' 'The Node 25 npx fallback must execute the exact pnpm version declared by Vencord.'
+        if (-not (Get-Command corepack -ErrorAction SilentlyContinue)) { Assert-Equal $pnpm.Command 'npx' 'Without Corepack the resolver must select npx.' }
+    }
+} finally { Remove-Item $tempPackage -Force -ErrorAction SilentlyContinue }
+
+$temp = Join-Path ([IO.Path]::GetTempPath()) ("orion-bundle-test-" + [guid]::NewGuid().ToString('N'))
+try {
+    $vencordRoot = Join-Path $temp 'Roaming\Vencord'
+    $customRoot = Join-Path $temp 'Local\OtherVencord'
+    New-Item -ItemType Directory -Force -Path $vencordRoot, $customRoot | Out-Null
+    $asar = Join-Path $temp 'app.asar'
+    $expected = [IO.Path]::GetFullPath((Join-Path $vencordRoot 'dist\patcher.js'))
+
+    $collision = $expected + '.backup'
+    $serializedCollision = $collision.Replace('\', '\\')
+    Set-Content -LiteralPath $asar -Value ("binary-header require(`"$serializedCollision`") tail") -Encoding UTF8
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $BundleVerifier -AppAsar $asar -VencordRoot $vencordRoot
+    Assert-Equal $LASTEXITCODE 1 'Bundle verifier must reject a prefix collision instead of substring-matching our patcher path.'
+
+    $serialized = $expected.Replace('\', '\\')
+    Set-Content -LiteralPath $asar -Value ("binary-header require(`"$serialized`") tail") -Encoding UTF8
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $BundleVerifier -AppAsar $asar -VencordRoot $vencordRoot
+    Assert-Equal $LASTEXITCODE 0 'Bundle verifier must accept a stub pointing at the shared Vencord dist.'
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $BundleVerifier -AppAsar $asar -VencordRoot $customRoot
+    Assert-Equal $LASTEXITCODE 1 'Bundle verifier must reject a stub pointing at a different Vencord checkout.'
+    $global:LASTEXITCODE = 0
+} finally { Remove-Item $temp -Recurse -Force -ErrorAction SilentlyContinue }
+
+$temp = Join-Path ([IO.Path]::GetTempPath()) ("orion-bundle-cmd-test-" + [guid]::NewGuid().ToString('N'))
+$oldAppData = $env:APPDATA
+$oldLocalAppData = $env:LOCALAPPDATA
+try {
+    $roaming = Join-Path $temp 'Roaming'
+    $local = Join-Path $temp 'Local'
+    $bundleCopy = Join-Path $temp 'bundle'
+    $vencordDist = Join-Path $roaming 'Vencord\dist'
+    $stableResources = Join-Path $local 'Discord\app-1.0.100\resources'
+    $canaryResources = Join-Path $local 'DiscordCanary\app-1.0.200\resources'
+    New-Item -ItemType Directory -Force -Path $bundleCopy, $vencordDist, $stableResources, $canaryResources | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $bundleCopy 'dist') | Out-Null
+
+    Copy-Item (Join-Path $BundleDir 'INSTALL.cmd') $bundleCopy
+    Copy-Item $BundleVerifier $bundleCopy
+    Set-Content -LiteralPath (Join-Path $bundleCopy 'dist\patcher.js') -Value "// Vencord deadbeef`n// Standalone: true`n// Updater Disabled: true`norion-patcher" -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $bundleCopy 'dist\preload.js') -Value "// Vencord deadbeef`norion-preload" -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $bundleCopy 'dist\renderer.js') -Value "// Vencord deadbeef`nOrionQuests`norion-renderer" -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $bundleCopy 'dist\renderer.css') -Value 'orion-css' -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $vencordDist 'patcher.js') -Value 'official-patcher' -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $vencordDist 'preload.js') -Value 'official-preload' -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $vencordDist 'renderer.js') -Value 'official-renderer' -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $vencordDist 'renderer.css') -Value 'official-css' -Encoding ASCII
+
+    New-Item -ItemType File -Force -Path (Join-Path $local 'Discord\Update.exe'), (Join-Path $local 'DiscordCanary\Update.exe') | Out-Null
+    Set-Content -LiteralPath (Join-Path $stableResources 'app.asar') -Value 'plain discord app' -Encoding UTF8
+    $sharedPatcher = [IO.Path]::GetFullPath((Join-Path $vencordDist 'patcher.js'))
+    $serializedSharedPatcher = $sharedPatcher.Replace('\', '\\')
+    Set-Content -LiteralPath (Join-Path $canaryResources 'app.asar') -Value ("require(`"$serializedSharedPatcher`")") -Encoding UTF8
+
+    $env:APPDATA = $roaming
+    $env:LOCALAPPDATA = $local
+    Push-Location $bundleCopy
+    try {
+        & cmd.exe /d /c 'INSTALL.cmd <nul'
+        $bundleExit = $LASTEXITCODE
+    } finally { Pop-Location }
+
+    Assert-Equal $bundleExit 0 'Simple bundle INSTALL.cmd must complete successfully in the isolated Canary smoke test.'
+    Assert-True ((Get-Content -LiteralPath (Join-Path $vencordDist 'patcher.js') -Raw).Contains('orion-patcher')) 'Bundle installer must copy the bundled patcher into the shared Vencord dist.'
+    Assert-True ((Get-Content -LiteralPath (Join-Path $vencordDist 'renderer.js') -Raw).Contains('orion-renderer')) 'Bundle installer must copy the bundled renderer into the shared Vencord dist.'
+    $backupDist = Join-Path $roaming 'Vencord\dist.orion-backup'
+    Assert-Equal ((Get-Content -LiteralPath (Join-Path $backupDist 'patcher.js') -Raw).Trim()) 'official-patcher' 'Bundle installer must preserve the original patcher in its recovery backup.'
+    Assert-Equal ((Get-Content -LiteralPath (Join-Path $backupDist 'renderer.js') -Raw).Trim()) 'official-renderer' 'Bundle installer must preserve the original renderer in its recovery backup.'
+} finally {
+    $env:APPDATA = $oldAppData
+    $env:LOCALAPPDATA = $oldLocalAppData
+    Remove-Item $temp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$install = Get-Content (Join-Path $DevbuildDir 'install-autoupdate.ps1') -Raw
+$update = Get-Content (Join-Path $DevbuildDir 'update.ps1') -Raw
+$uninstall = Get-Content (Join-Path $DevbuildDir 'uninstall.ps1') -Raw
+$helperText = Get-Content $Helper -Raw
+$devReadme = Get-Content (Join-Path $DevbuildDir 'README.txt') -Raw
+$bundle = Get-Content (Join-Path $BundleDir 'INSTALL.cmd') -Raw
+$workflowText = Get-Content $Workflow -Raw
+$packagerText = Get-Content $Packager -Raw
+
+foreach ($pair in @(@{Name='install-autoupdate.ps1';Text=$install},@{Name='update.ps1';Text=$update},@{Name='uninstall.ps1';Text=$uninstall})) {
+    Assert-True ($pair.Text -match 'installer-common\.ps1') "$($pair.Name) must use the shared tested installer helpers."
+    Assert-False ($pair.Text -match 'Get-Process[^\r\n]*\bUpdate\b') "$($pair.Name) must not kill every process named Update.exe."
+}
+
+Assert-True ($helperText -match 'remaining' -and $helperText -match 'throw') 'Stop-DiscordProcesses must fail if Discord is still alive after its timeout.'
+Assert-True ($helperText -match 'serializedExpected') 'app.asar ownership verification must compare the complete JSON-quoted patcher path.'
+Assert-True ($helperText -match 'Restore-VencordAppAsar') 'Shared helper must expose a verified app.asar restore path.'
+Assert-True ($helperText -match 'Write-OrionVencordHealthStamp') 'Managed Vencord builds must persist a runtime health stamp after semantic verification.'
+Assert-True ($helperText -match 'Test-OrionVencordDistHealthy') 'Transactional rollback must require a previously stamped healthy dist.'
+Assert-True ($helperText -match 'Get-FileHash[^\r\n]*SHA256') 'The Vencord health stamp must bind the runtime files with SHA-256 hashes.'
+Assert-True ($install -match 'Get-DiscordReopenSet') 'Install must derive its reopen set from the patched target plus previously running clients.'
+Assert-True ($install -match 'Test-AppAsarPointsToPatcher') 'Install verification must use the exact OrionVencord patcher path.'
+Assert-False ($install -match "-like '\*OrionVencord\*'") 'Install verification must not use a loose OrionVencord substring.'
+Assert-False ($install -match 'corepack is missing') 'Install must not reject supported Node versions solely because bundled Corepack is absent.'
+Assert-True ($install -match 'Invoke-Pnpm') 'Install must use the shared pnpm invocation that supports Node 25+.'
+Assert-True ($install -match 'Restore-VencordAppAsar') 'Install rollback must use the checked restore helper when Vencord unpatch does not verify.'
+Assert-True ($install -match 'rollback could not be verified') 'Install must fail closed when rollback cannot be verified.'
+Assert-True ($update -match '\$fetchCode') 'Plugin update fallback must record git fetch success explicitly.'
+Assert-True ($update -match '\$resetCode') 'Plugin update fallback must record git reset success explicitly.'
+Assert-True ($update -match '\$fetchCode\s*-eq\s*0\s*-and\s*\$resetCode\s*-eq\s*0') 'A stale FETCH_HEAD reset must not be reported as a successful plugin update.'
+Assert-True ($update -match 'keeping the existing checkout') 'A transient GitHub failure must preserve an existing usable plugin checkout instead of deleting it.'
+Assert-True ($update -match '\$existingCheckoutUsable') 'Update must explicitly gate preservation on a usable existing plugin checkout.'
+Assert-True ($update -match 'Get-RunningDiscordFlavors') 'Update must remember which Discord flavor(s) were running before restart.'
+Assert-True ($update -match 'Start-DiscordFlavors') 'Update must reopen the same running flavor(s), not the first installed flavor.'
+Assert-True ($uninstall -match 'Restore-VencordAppAsar') 'Uninstall must only count a restore after the checked restore helper succeeds.'
+Assert-False ($uninstall -match "-notlike '\*OrionVencord\*'") 'Uninstall must not use a loose OrionVencord substring.'
+Assert-True ($uninstall -match 'Do NOT delete') 'A partial uninstall must warn users not to delete OrionVencord before Repair/Uninstall succeeds.'
+Assert-True ($uninstall -match 'Discord was left closed') 'A partial uninstall must fail closed instead of reopening a potentially broken client.'
+Assert-True ($uninstall -match 'Get-RunningDiscordFlavors') 'Uninstall must remember which Discord flavor(s) were running before restart.'
+Assert-True ($uninstall -match 'Start-DiscordFlavors') 'Successful uninstall must reopen the same running flavor(s), not the first installed flavor.'
+Assert-True ($devReadme -match 'DiscordCanary') 'Recovery documentation must include the Canary install root.'
+Assert-True ($devReadme -match 'DiscordPTB') 'Recovery documentation must include the PTB install root.'
+Assert-False ($packagerText.Contains("StartsWith('_')")) 'Release packaging must not ignore underscore-prefixed userplugin entries because native discovery still scans them.'
+Assert-False ($packagerText.Contains("StartsWith('.')")) 'Release packaging must not ignore dot-prefixed userplugin entries because native discovery still scans them.'
+Assert-True ($packagerText.Contains('additional Vencord userplugin entries are present')) 'Release packaging must fail closed on foreign userplugin entries instead of relying on a marker blacklist.'
+
+foreach ($needle in @('Discord.exe','DiscordCanary.exe','DiscordPTB.exe','WAS_CANARY','WAS_PTB','PATCHED_STABLE','PATCHED_CANARY','PATCHED_PTB','check_vencord_target','verify-vencord-target.ps1','discord_still_running','backup_failed','copy_failed','restore_failed','invalid_backup')) {
+    Assert-True ($bundle.Contains($needle)) "Simple bundle installer is missing '$needle'."
+}
+Assert-True ($bundle -match 'WAS_CANARY.+PATCHED_CANARY') 'Running Canary must be rejected when Canary itself does not point at the shared Vencord build.'
+Assert-True ($bundle -match 'WAS_PTB.+PATCHED_PTB') 'Running PTB must be rejected when PTB itself does not point at the shared Vencord build.'
+Assert-True ($bundle.Contains('goto :discord_still_running')) 'Bundle must verify taskkill actually closed Discord before copying Vencord files.'
+Assert-True ($bundle.Contains('Could not create a complete Vencord backup')) 'Bundle must fail safely when its first backup cannot be completed.'
+Assert-True ($bundle.Contains('Automatic rollback also failed')) 'Bundle must surface rollback failure instead of claiming the original Vencord was restored.'
+Assert-True ($bundle.Contains('call :check_dist_complete "%APPDATA%\Vencord\dist.orion-backup"')) 'Bundle recovery validation must apply the complete runtime manifest to its saved backup.'
+Assert-True ($workflowText.Contains('tools/package-release.ps1')) 'Installer CI must run when release packaging changes.'
+Assert-True ($workflowText.Contains('shell: powershell')) 'Installer CI must exercise Windows PowerShell 5.1, which the shipped CMD wrappers use.'
+Assert-True ($workflowText.Contains('shell: pwsh')) 'Installer CI must also exercise PowerShell 7.'
+
+Write-Host 'Installer regression tests passed.' -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## Summary

This is a follow-up to #70.

While reviewing the Windows installer paths around #69, I found several reliability issues that were broader than Canary/PTB support itself. Rather than expanding #70 beyond its original scope, this PR keeps those changes separate and focuses on install/update/recovery hardening.

The changes cover both installer variants:

- the prebuilt Vencord bundle
- the source/devbuild auto-update installer

It also adds Windows regression coverage for the installer scripts.

## Problems fixed

### Prebuilt bundle installer

#### 1. A Discord flavor being installed did not prove that Vencord was actually injected into that flavor

The installer could successfully replace `%APPDATA%\Vencord\dist`, reopen a Discord client, and report success even when that client was not actually patched to use the shared Vencord installation.

This is especially easy to hit on machines with multiple Stable/Canary/PTB installations.

The installer now verifies the active `app.asar` target before modifying the shared Vencord dist and fails closed when the selected client does not point at the expected Vencord installation.

---

#### 2. The installer did not validate the complete Vencord desktop runtime

Previously, an existing `dist` directory was effectively enough to continue.

A usable desktop Vencord build requires all of:

- `patcher.js`
- `preload.js`
- `renderer.js`
- `renderer.css`

The installer now verifies that all four files exist and are non-empty before using a dist as an install or recovery source.

The bundled Orion build is also checked for the expected standalone/updater-disabled Orion markers before touching the user's Vencord installation.

---

#### 3. Backup handling could preserve a stale or incomplete Vencord state

`dist.orion-backup` was previously a very simple one-time backup.

That means a user could:

1. install Orion,
2. later repair/update Vencord,
3. run the Orion installer again,
4. still have an old backup from the first install.

Copy failures could also leave the live dist partially replaced.

The replacement flow is now staged and verified, with rollback when the new dist cannot be installed successfully.

The backup is refreshed from the current usable Vencord state instead of blindly preserving an old recovery copy forever.

---

#### 4. Discord's own updater could race the dist replacement

Discord uses a generic `Update.exe`.

Stopping every process with that name is unsafe, but leaving Discord's updater active while replacing shared Vencord files can also cause a race.

The installer now only stops updater processes whose executable path belongs to the Discord Stable/Canary/PTB installation roots.

---

#### 5. A client that was closed by the installer could be replaced by a different Discord flavor on reopen

This is the edge case discussed after #70.

Example:

1. Canary is running.
2. The installer closes Canary.
3. Canary's `Update.exe` is no longer available when reopening.
4. Stable is the only remaining launchable installation.
5. The old fallback logic could open Stable instead.

The important state is not only "did we start anything?", but also "did we close something that we could not put back?"

The installer now records that condition and suppresses the single-install fallback if any flavor it closed cannot be restored.

It leaves Discord closed and asks the user to start the intended client manually instead of silently opening a different flavor.

---

## Devbuild / auto-update installer

### 6. Multiple installed Discord flavors could resolve to the wrong target

The devbuild installer previously treated installed flavors in preference order, which could select Stable even when the user was actively using Canary or PTB.

Flavor resolution now considers the running client first and avoids silently guessing when multiple valid targets remain.

An explicit `-DiscordBranch stable|canary|ptb` override is also supported.

Stale Discord directories without a usable active `app-*` tree or `Update.exe` are not considered launchable installations.

---

### 7. Node versions without bundled Corepack could not use the installer (Node 25 or newer)

The installer previously required `corepack`.

That breaks on newer Node releases where Corepack may not be bundled.

The installer now reads the exact pnpm version declared by Vencord's `packageManager` field and uses:

1. Corepack when available
2. an exact-version `npx` fallback otherwise

This keeps the Vencord-requested pnpm version instead of installing an arbitrary latest version.

---

### 8. A failed Vencord build could leave a mixed `dist`

Vencord produces several desktop runtime outputs independently.

If a rebuild fails after some outputs have already been written, simply checking that the files exist can preserve a mixture of old and new build artifacts.

Managed builds are now transactional.

After a successful build the installer records a SHA-256 health stamp for:

- `patcher.js`
- `preload.js`
- `renderer.js`
- `renderer.css`

A previous dist is only considered rollback-safe when:

- all runtime files are complete,
- Orion is present,
- the JavaScript runtime files identify the same Vencord revision,
- and all four hashes still match the last successful managed build.

A failed or externally modified dist is not silently promoted to known-good recovery state.

---

### 9. `app.asar` recovery could report success with an unusable backup

Restoring `_app.asar` by rename alone is not enough to prove recovery succeeded.

The restore path now rejects missing or zero-byte backups and verifies that the restored file no longer points at the Orion/Vencord patcher before reporting success.

If recovery cannot be proven, Discord is left closed rather than reopening into a known-bad state.

---

### 10. Update/uninstall/install lifecycle logic was duplicated across scripts

Flavor detection, process handling, runtime validation and recovery behavior were previously implemented independently by several scripts.

The common lifecycle logic now lives in `installer-common.ps1`, including:

- Discord flavor metadata
- installed/running flavor discovery
- launchability checks
- Vencord runtime validation
- pnpm resolution
- process shutdown/restart handling
- `app.asar` ownership/recovery
- transactional dist health checks

This reduces the chance of install, update and uninstall gradually developing different rules for the same machine state.