### PR TITLE
fix(plugin): move version below description for UserpluginInstaller

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -413,9 +413,13 @@ async function controlQuestById(questId: string, action: "pause" | "resume"): Pr
 
 export default definePlugin({
     name: "OrionQuests",
-    version: PLUGIN_VERSION,
     description:
         "Auto-completes Discord Quests: game, video, stream, activity, and achievement.",
+    // version sits below description because UserpluginInstaller reads plugin metadata with a
+    // regex that only tolerates whitespace and comments between name and description. Any key in
+    // that gap makes the match fail, and the plugin then never appears in its UserPlugins tab,
+    // which also takes away its uninstall and update buttons.
+    version: PLUGIN_VERSION,
     authors: [{ name: "syntt_", id: 1419678867005767783n }],
     dependencies: ["UserSettingsAPI"],
     settings,


### PR DESCRIPTION
## Summary

Moves the `version` key below `description` in the `definePlugin` block so UserpluginInstaller can read Orion's metadata.

## Why

UserpluginInstaller builds its UserPlugins tab by reading each plugin's index file with a regex that only allows whitespace and comments between `name` and `description`. Our `version` key sits between them, so the match returns null, `getPluginMeta` throws on `rawMeta![1]`, and the settled-results filter drops the plugin.

Orion installs, runs, and shows up in the normal Plugins list, but nothing appears in the UserPlugins tab. The uninstall and update buttons come off that same list, so those are gone too. Reinstalling through the installer clones the repo and then shows nothing.

The regex is the underlying problem, and it is not only us. AMRPCStatusDisplayType in the userplugins org has `tags` in the same gap and disappears the same way. I opened a PR against the installer to replace the regex with a real parser and the maintainer closed it, so moving the key here is the fix that lands. It also works with every installer version already out there.

## Changes

- `index.tsx`: `version: PLUGIN_VERSION` now sits after `description`.
- A comment above it explains the ordering, so it does not get tidied back later.

## Testing

- Ran the installer's own `PLUGIN_META_REGEX` against `index.tsx` before and after. Before: no match. After: `{"name":"OrionQuests","description":"Auto-completes Discord Quests: game, video, stream, activity, and achievement."}`.
- Rebuilt Vencord (`pnpm build --dev`, exit 0) and restarted Discord. OrionQuests now shows in the UserPlugins tab with its description, Source link and delete button.
- No behavior change. The key moved inside the same object literal, `PLUGIN_VERSION` is unchanged, and `tools/package-release.ps1` matches the `PLUGIN_VERSION = "vX.Y.Z"` declaration rather than key order.
- The userscript checks in the template (`eslint` / `node --check` on `index.js`, console paste, STOP shutdown) do not apply here. This touches the Vencord plugin entry only.

## Checklist

- [ ] `CONFIG.VERSION` bumped (if user-facing). Not applicable, no user-facing behavior change.
- [ ] README changelog updated at the top of the list. Not applicable for the same reason, happy to add an entry if you want one.
- [ ] ARCHITECTURE.md updated if structure changed. No structural change.
- [x] Commit messages follow conventional commit style.
- [x] No debug `console.log` left behind.