### PR TITLE
feat: expose structured companion events

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -8,7 +8,7 @@ on:
       - "tools/orion-devbuild-installer/**"
       - "tools/orion-vencord-bundle/**"
       - "tools/package-release.ps1"
-      - "tools/tests/installer-regression.ps1"
+      - "tools/tests/**"
       - ".github/workflows/installer.yml"
   pull_request:
     branches: [main]
@@ -16,7 +16,7 @@ on:
       - "tools/orion-devbuild-installer/**"
       - "tools/orion-vencord-bundle/**"
       - "tools/package-release.ps1"
-      - "tools/tests/installer-regression.ps1"
+      - "tools/tests/**"
       - ".github/workflows/installer.yml"
 
 jobs:
@@ -43,8 +43,8 @@ jobs:
               $tokens = $null
               $errors = $null
               [void][System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors)
-              foreach ($error in $errors) {
-                  Write-Error "$($_.FullName):$($error.Extent.StartLineNumber): $($error.Message)"
+              foreach ($parseError in $errors) {
+                  Write-Error "$($_.FullName):$($parseError.Extent.StartLineNumber): $($parseError.Message)"
                   $failed = $true
               }
           }
@@ -52,7 +52,10 @@ jobs:
 
       - name: Run regression suite with Windows PowerShell 5.1
         shell: powershell
-        run: .\tools\tests\installer-regression.ps1
+        run: |
+          .\tools\tests\installer-regression.ps1
+          .\tools\tests\companion-update-regression.ps1
+          .\tools\tests\companion-update-fingerprint-regression.ps1
 
       - name: Parse scripts with PowerShell 7
         shell: pwsh
@@ -62,8 +65,8 @@ jobs:
               $tokens = $null
               $errors = $null
               [void][System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$tokens, [ref]$errors)
-              foreach ($error in $errors) {
-                  Write-Error "$($_.FullName):$($error.Extent.StartLineNumber): $($error.Message)"
+              foreach ($parseError in $errors) {
+                  Write-Error "$($_.FullName):$($parseError.Extent.StartLineNumber): $($parseError.Message)"
                   $failed = $true
               }
           }
@@ -71,4 +74,7 @@ jobs:
 
       - name: Run regression suite with PowerShell 7
         shell: pwsh
-        run: .\tools\tests\installer-regression.ps1
+        run: |
+          .\tools\tests\installer-regression.ps1
+          .\tools\tests\companion-update-regression.ps1
+          .\tools\tests\companion-update-fingerprint-regression.ps1

--- a/.github/workflows/vencord-plugin.yml
+++ b/.github/workflows/vencord-plugin.yml
@@ -92,6 +92,7 @@ jobs:
           grep -q "QUESTS_ENROLL_SUCCESS" dist/renderer.js
           grep -q "getControlSnapshot" dist/renderer.js
           grep -q "subscribeControlState" dist/renderer.js
+          grep -q "subscribeEvents" dist/renderer.js
           grep -q "controlAll" dist/renderer.js
           grep -q "controlQuest" dist/renderer.js
           grep -q "Unsupported Orion global task action" dist/renderer.js

--- a/companionEvents.ts
+++ b/companionEvents.ts
@@ -1,0 +1,250 @@
+/*
+ * OrionQuests companion event contract.
+ *
+ * Human-readable Logger output is intentionally not the machine API. Companion consumers get
+ * explicit event identity and failure metadata here, while Orion keeps ownership of persistence,
+ * retries, scheduling, and engine state.
+ */
+
+export type CompanionEventLevel = "debug" | "info" | "success" | "warning" | "error";
+export type CompanionEventCategory =
+    | "startup"
+    | "system"
+    | "cycle"
+    | "quest"
+    | "enroll"
+    | "task"
+    | "claim"
+    | "network"
+    | "achievement"
+    | "bypass"
+    | "patcher";
+export type CompanionEventStability = "stable" | "provisional";
+
+/**
+ * Stable codes describe semantic lifecycle facts Orion already treats as public behavior.
+ * Provisional codes are diagnostic/cycle detail: consumers may display them, but should not make
+ * control decisions from them until their semantics have settled through real companion use.
+ */
+export const COMPANION_EVENT_CODES = {
+    ENGINE_STARTED: "engine.started",
+    ENGINE_START_FAILED: "engine.start_failed",
+    ENGINE_FAILED: "engine.failed",
+    ENGINE_STOPPED: "engine.stopped",
+    QUEST_BLOCKED: "quest.blocked",
+    ENROLL_WAITING: "enroll.waiting",
+    ENROLL_STARTED: "enroll.started",
+    ENROLL_FAILED: "enroll.failed",
+    TASK_STARTED: "task.started",
+    TASK_COMPLETED: "task.completed",
+    TASK_FAILED: "task.failed",
+    CLAIM_SUCCEEDED: "claim.succeeded",
+    CLAIM_ACTION_REQUIRED: "claim.action_required",
+    CLAIM_FAILED: "claim.failed",
+    NETWORK_RETRY: "network.retry",
+    NETWORK_FAILED: "network.failed",
+    HEARTBEAT_FAILURE: "heartbeat.failure",
+    HEARTBEAT_GIVE_UP: "heartbeat.give_up",
+    ACHIEVEMENT_FALLBACK: "achievement.fallback",
+    BYPASS_STARTED: "bypass.started",
+    BYPASS_SUCCEEDED: "bypass.succeeded",
+    BYPASS_FAILED: "bypass.failed",
+    STARTUP_QUEST_LIST_WAITING: "startup.quest_list_waiting",
+    STARTUP_QUEST_LIST_ARRIVED: "startup.quest_list_arrived",
+    STARTUP_QUEST_LIST_TIMEOUT: "startup.quest_list_timeout",
+    CYCLE_STARTED: "cycle.started",
+    CYCLE_PROCESSING: "cycle.processing",
+    CYCLE_COMPLETED: "cycle.completed",
+    CYCLE_FAILED: "cycle.failed",
+    SYSTEM_ACCOUNT_CHANGED: "system.account_changed",
+    SYSTEM_QUEST_ACCESS_SUSPENDED: "system.quest_access_suspended",
+    SYSTEM_ENROLLMENT_BLOCKED: "system.enrollment_blocked",
+    SYSTEM_QUEST_LIST_MISSING: "system.quest_list_missing",
+    SYSTEM_RUN_SUMMARY: "system.run_summary",
+    PATCHER_PRESENCE_RESTORED: "patcher.presence_restored",
+    PATCHER_PRESENCE_RESTORE_FAILED: "patcher.presence_restore_failed",
+} as const;
+
+export type CompanionEventCode = typeof COMPANION_EVENT_CODES[keyof typeof COMPANION_EVENT_CODES];
+
+export const COMPANION_EVENT_CODE_STABILITY: Readonly<Record<CompanionEventCode, CompanionEventStability>> = Object.freeze({
+    [COMPANION_EVENT_CODES.ENGINE_STARTED]: "stable",
+    [COMPANION_EVENT_CODES.ENGINE_START_FAILED]: "stable",
+    [COMPANION_EVENT_CODES.ENGINE_FAILED]: "stable",
+    [COMPANION_EVENT_CODES.ENGINE_STOPPED]: "stable",
+    [COMPANION_EVENT_CODES.QUEST_BLOCKED]: "stable",
+    [COMPANION_EVENT_CODES.ENROLL_WAITING]: "stable",
+    [COMPANION_EVENT_CODES.ENROLL_STARTED]: "stable",
+    [COMPANION_EVENT_CODES.ENROLL_FAILED]: "stable",
+    [COMPANION_EVENT_CODES.TASK_STARTED]: "stable",
+    [COMPANION_EVENT_CODES.TASK_COMPLETED]: "stable",
+    [COMPANION_EVENT_CODES.TASK_FAILED]: "stable",
+    [COMPANION_EVENT_CODES.CLAIM_SUCCEEDED]: "stable",
+    [COMPANION_EVENT_CODES.CLAIM_ACTION_REQUIRED]: "stable",
+    [COMPANION_EVENT_CODES.CLAIM_FAILED]: "stable",
+    [COMPANION_EVENT_CODES.NETWORK_RETRY]: "stable",
+    [COMPANION_EVENT_CODES.NETWORK_FAILED]: "stable",
+    [COMPANION_EVENT_CODES.HEARTBEAT_FAILURE]: "stable",
+    [COMPANION_EVENT_CODES.HEARTBEAT_GIVE_UP]: "stable",
+    [COMPANION_EVENT_CODES.ACHIEVEMENT_FALLBACK]: "stable",
+    [COMPANION_EVENT_CODES.BYPASS_STARTED]: "stable",
+    [COMPANION_EVENT_CODES.BYPASS_SUCCEEDED]: "stable",
+    [COMPANION_EVENT_CODES.BYPASS_FAILED]: "stable",
+    [COMPANION_EVENT_CODES.STARTUP_QUEST_LIST_WAITING]: "provisional",
+    [COMPANION_EVENT_CODES.STARTUP_QUEST_LIST_ARRIVED]: "provisional",
+    [COMPANION_EVENT_CODES.STARTUP_QUEST_LIST_TIMEOUT]: "provisional",
+    [COMPANION_EVENT_CODES.CYCLE_STARTED]: "provisional",
+    [COMPANION_EVENT_CODES.CYCLE_PROCESSING]: "provisional",
+    [COMPANION_EVENT_CODES.CYCLE_COMPLETED]: "provisional",
+    [COMPANION_EVENT_CODES.CYCLE_FAILED]: "provisional",
+    [COMPANION_EVENT_CODES.SYSTEM_ACCOUNT_CHANGED]: "provisional",
+    [COMPANION_EVENT_CODES.SYSTEM_QUEST_ACCESS_SUSPENDED]: "provisional",
+    [COMPANION_EVENT_CODES.SYSTEM_ENROLLMENT_BLOCKED]: "provisional",
+    [COMPANION_EVENT_CODES.SYSTEM_QUEST_LIST_MISSING]: "provisional",
+    [COMPANION_EVENT_CODES.SYSTEM_RUN_SUMMARY]: "provisional",
+    [COMPANION_EVENT_CODES.PATCHER_PRESENCE_RESTORED]: "provisional",
+    [COMPANION_EVENT_CODES.PATCHER_PRESENCE_RESTORE_FAILED]: "provisional",
+});
+
+export interface CompanionEventFailure {
+    /** No more retry/fallback remains for the operation represented by this event. */
+    readonly terminal: boolean;
+    /** The underlying failure class permits retry, even if this event is the exhausted terminal one. */
+    readonly retryable: boolean;
+    /** 1-based operation attempt when Orion has a meaningful counter; otherwise null. */
+    readonly attempt: number | null;
+    readonly maxAttempts: number | null;
+    readonly httpStatus: number | null;
+    readonly upstreamCode: string | number | null;
+    readonly reason: string | null;
+}
+
+export interface CompanionFailureInput {
+    terminal: boolean;
+    retryable: boolean;
+    attempt?: number | null;
+    maxAttempts?: number | null;
+    httpStatus?: number | null;
+    upstreamCode?: string | number | null;
+    reason?: string | null;
+}
+
+export interface CompanionEvent {
+    readonly timestamp: number;
+    readonly code: CompanionEventCode;
+    readonly category: CompanionEventCategory;
+    readonly level: CompanionEventLevel;
+    /** Human context only. Consumers must use code/fields, not parse this string for meaning. */
+    readonly message: string;
+    readonly questId?: string;
+    readonly questName?: string;
+    readonly taskType?: string;
+    /** Structured non-failure reason, for example why a quest was deliberately skipped. */
+    readonly reason?: string;
+    readonly failure?: CompanionEventFailure;
+}
+
+export type CompanionEventInput = Omit<CompanionEvent, "timestamp"> & { timestamp?: number; };
+export type CompanionEventListener = (event: CompanionEvent) => void;
+
+const eventListeners = new Set<CompanionEventListener>();
+
+const SECRET_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+    // JSON/stringified error objects need their own forms because the quote after the key means
+    // a plain `key: value` pattern never reaches the colon.
+    [/(\[?\s*["']authorization["']\s*:\s*["'])(?:bearer\s+)?[^"']*(["'])/gi, "$1[REDACTED]$2"],
+    [/(\[?\s*["'](?:access[_-]?token|auth[_-]?token|proxy[_-]?ticket|discord_proxy_ticket|cookie|oauth[_-]?code|auth[_-]?code|token|ticket)["']\s*:\s*["'])[^"']*(["'])/gi, "$1[REDACTED]$2"],
+    [/(authorization\s*[:=]\s*)(?:bearer\s+)?[^\s,;]+/gi, "$1[REDACTED]"],
+    [/(access[_-]?token|auth[_-]?token|proxy[_-]?ticket|discord_proxy_ticket|cookie|token|ticket)\s*[:=]\s*[^\s,;&]+/gi, "$1=[REDACTED]"],
+    [/(oauth(?:[_\s-]?code)|auth(?:[_\s-]?code))\s*[:=]\s*[^\s,;&]+/gi, "$1=[REDACTED]"],
+    [/([?&](?:code|auth_code|oauth_code|token|access_token|auth_token|ticket|proxy_ticket|discord_proxy_ticket)=)[^&#\s]+/gi, "$1[REDACTED]"],
+];
+
+/** Defense-in-depth at the producer boundary: companions never receive known credential shapes. */
+export function sanitizeCompanionText(value: string): string {
+    let text = value;
+    for (const [pattern, replacement] of SECRET_PATTERNS) text = text.replace(pattern, replacement);
+    return text;
+}
+
+function finitePositiveInteger(value: number | null | undefined): number | null {
+    if (value == null || !Number.isFinite(value)) return null;
+    const normalized = Math.floor(value);
+    return normalized > 0 ? normalized : null;
+}
+
+function finiteHttpStatus(value: number | null | undefined): number | null {
+    const normalized = finitePositiveInteger(value);
+    return normalized != null && normalized >= 100 && normalized <= 599 ? normalized : null;
+}
+
+export function companionFailure(input: CompanionFailureInput): CompanionEventFailure {
+    const attempt = finitePositiveInteger(input.attempt);
+    let maxAttempts = finitePositiveInteger(input.maxAttempts);
+    // Do not publish an impossible counter pair. Null is preferable to inventing a larger budget
+    // when a producer supplied maxAttempts smaller than the attempt that actually occurred.
+    if (attempt != null && maxAttempts != null && maxAttempts < attempt) maxAttempts = null;
+
+    return Object.freeze({
+        terminal: input.terminal,
+        retryable: input.retryable,
+        attempt,
+        maxAttempts,
+        httpStatus: finiteHttpStatus(input.httpStatus),
+        upstreamCode: typeof input.upstreamCode === "string"
+            ? sanitizeCompanionText(input.upstreamCode)
+            : typeof input.upstreamCode === "number" ? input.upstreamCode : null,
+        reason: typeof input.reason === "string" && input.reason.length > 0
+            ? sanitizeCompanionText(input.reason)
+            : null,
+    });
+}
+
+export function subscribeCompanionEvents(listener: CompanionEventListener): () => void {
+    eventListeners.add(listener);
+    let active = true;
+    return () => {
+        if (!active) return;
+        active = false;
+        eventListeners.delete(listener);
+    };
+}
+
+export function emitCompanionEvent(input: CompanionEventInput): void {
+    // task.failed is the terminal task-generation boundary. Keep its failure shape total even for
+    // local failures such as timeouts/no-channel cases that have no HTTP metadata to contribute.
+    const sourceFailure = input.failure ?? (input.code === COMPANION_EVENT_CODES.TASK_FAILED
+        ? companionFailure({ terminal: true, retryable: false, reason: input.reason ?? null })
+        : undefined);
+    // Normalize again at the delivery boundary so a future producer cannot bypass counter/status
+    // validation by constructing a CompanionEventFailure object directly instead of using the
+    // helper above.
+    const failure = sourceFailure ? companionFailure(sourceFailure) : undefined;
+    const event = Object.freeze({
+        ...input,
+        message: sanitizeCompanionText(input.message),
+        ...(input.reason ? { reason: sanitizeCompanionText(input.reason) } : {}),
+        timestamp: Number.isFinite(input.timestamp) ? Number(input.timestamp) : Date.now(),
+        ...(failure ? { failure } : {}),
+    }) as CompanionEvent;
+
+    // Capture subscribers at the emission boundary, then deliver on the next microtask. Events
+    // stay FIFO, and unsubscribe still affects only later emissions, but an observer cannot
+    // synchronously re-enter Stop/Pause in the middle of the engine transition it is observing.
+    // That keeps this API observational rather than turning it into an accidental pre-action hook.
+    const listeners = Array.from(eventListeners);
+    queueMicrotask(() => {
+        for (const listener of listeners) {
+            try {
+                listener(event);
+            } catch (error) {
+                console.error("[OrionQuests] Companion event listener threw:", error);
+            }
+        }
+    });
+}
+
+/** Test-only lifecycle helper; production subscribers own their unsubscribe callbacks. */
+export function clearCompanionEventListeners(): void {
+    eventListeners.clear();
+}

--- a/index.tsx
+++ b/index.tsx
@@ -10,6 +10,7 @@
 import { ApplicationCommandInputType, ApplicationCommandOptionType, sendBotMessage } from "@api/Commands";
 import definePlugin from "@utils/types";
 
+import { subscribeCompanionEvents, type CompanionEventListener } from "./companionEvents";
 import { setWatchForEnrollmentsHook } from "./hooks";
 import {
     getCurrentUserId,
@@ -450,6 +451,12 @@ export default definePlugin({
 
     subscribeControlState(listener: () => void): () => void {
         return subscribeDashboard(listener);
+    },
+
+    // Additive read-only diagnostics capability. Older companions keep using the existing
+    // control surface and console fallback; consumers feature-detect this method independently.
+    subscribeEvents(listener: CompanionEventListener): () => void {
+        return subscribeCompanionEvents(listener);
     },
 
     async controlEngine(action: "start" | "stop"): Promise<string> {

--- a/orion.ts
+++ b/orion.ts
@@ -14,6 +14,7 @@ import { findByProps, findStore } from "@webpack";
 import { FluxDispatcher, RestAPI } from "@webpack/common";
 
 import { isConfirmedDifferentAccount } from "./accountIdentity";
+import { companionFailure, COMPANION_EVENT_CODES, emitCompanionEvent } from "./companionEvents";
 import { setAchievementBypassHook } from "./hooks";
 import { Patcher } from "./patcher";
 import { questBlocker, recordOutcome, selectQuestTaskConfig, summarizeRun, taskEntries } from "./questConfig";
@@ -107,9 +108,29 @@ let sessionOwnerUserId: string | null = null;
  */
 let lastRunOutcome: string | null = null;
 let accountResetInProgress = false;
+let dashboardDispatchDepth = 0;
+let stopQueued = false;
+
+function retryableHttpStatus(error: any): boolean {
+    const status = error?.status ?? error?.statusCode ?? error?.httpStatus;
+    return status === 408 || status === 429 || status >= 500;
+}
+
+function failureFromError(error: any, terminal: boolean, retryable: boolean, reason: string): ReturnType<typeof companionFailure> {
+    const rawStatus = error?.status ?? error?.statusCode ?? error?.httpStatus;
+    const rawCode = error?.body?.code ?? error?.code;
+    return companionFailure({
+        terminal,
+        retryable,
+        httpStatus: Number.isFinite(rawStatus) ? Number(rawStatus) : null,
+        upstreamCode: typeof rawCode === "string" || typeof rawCode === "number" ? rawCode : null,
+        reason,
+    });
+}
 
 function isRunActive(runId: number, runRuntime: OrionRuntime): boolean {
-    return RUNTIME.running
+    return !stopQueued
+        && RUNTIME.running
         && runRuntime.running
         && activeRunId === runId
         && activeRuntime === runRuntime;
@@ -166,8 +187,13 @@ export function getCurrentUserId(): string | null {
 }
 
 function emitDashboard(): void {
-    for (const fn of dashboardListeners) {
-        try { fn(); } catch (e: any) { debug(logger, `[UI] listener threw: ${e?.message}`); }
+    dashboardDispatchDepth++;
+    try {
+        for (const fn of dashboardListeners) {
+            try { fn(); } catch (e: any) { debug(logger, `[UI] listener threw: ${e?.message}`); }
+        }
+    } finally {
+        dashboardDispatchDepth--;
     }
 }
 
@@ -189,6 +215,12 @@ function removeEntry(id: string): void {
 export function resetForAccountChange(): void {
     if (accountResetInProgress) return;
     accountResetInProgress = true;
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.SYSTEM_ACCOUNT_CHANGED,
+        category: "system",
+        level: "warning",
+        message: "Discord account changed; Orion is clearing account-scoped runtime state.",
+    });
 
     try {
         // Observable account-owned state goes first. stopOrion() emits synchronously, and a
@@ -419,6 +451,15 @@ async function onTaskComplete(
     // The one place the run knows a quest finished because of its own work. Everything the
     // wrap-up says about this run is counted from here, failTask and the blocker below.
     recordOutcome(runRuntime.outcomes, q.id, "completed");
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.TASK_COMPLETED,
+        category: "task",
+        level: "success",
+        message: `Task completed for "${t.name}".`,
+        questId: q.id,
+        questName: t.name,
+        taskType: t.type,
+    });
     logger.info(`[Task] Completed "${t.name}"!`);
     Sound.play("tick");
 
@@ -435,6 +476,15 @@ async function onTaskComplete(
             if (!isTaskActive(runId, runRuntime, controlled)) return;
             if (claimRes?.body?.claimed_at) {
                 logger.info(`[Claim] Reward for "${t.name}" claimed automatically!`);
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.CLAIM_SUCCEEDED,
+                    category: "claim",
+                    level: "success",
+                    message: `Reward claimed automatically for "${t.name}".`,
+                    questId: q.id,
+                    questName: t.name,
+                    taskType: t.type,
+                });
                 setEntry(q.id, { name: t.name, type: t.type, cur: t.target, max: t.target, status: "CLAIMED" });
                 const claimedEntry = dashboard.get(q.id);
                 setTimeout(() => {
@@ -445,8 +495,34 @@ async function onTaskComplete(
         } catch (e: any) {
             if (!isTaskActive(runId, runRuntime, controlled)) return;
             const needsCaptcha = e?.body?.captcha_key || e?.body?.captcha_sitekey;
-            if (needsCaptcha) logger.warn(`[Claim] Captcha required for "${t.name}". Use Discord's UI button.`);
-            else logger.error(`[Claim] Auto-claim failed for "${t.name}": ${e?.body?.message ?? e?.message}`);
+            if (needsCaptcha) {
+                const reason = "Captcha required; claim the reward in Discord's UI";
+                logger.warn(`[Claim] Captcha required for "${t.name}". Use Discord's UI button.`);
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.CLAIM_ACTION_REQUIRED,
+                    category: "claim",
+                    level: "warning",
+                    message: `Reward claim for "${t.name}" requires user action in Discord.`,
+                    questId: q.id,
+                    questName: t.name,
+                    taskType: t.type,
+                    reason,
+                });
+            } else {
+                const reason = String(e?.body?.message ?? e?.message ?? "Claim request failed");
+                logger.error(`[Claim] Auto-claim failed for "${t.name}": ${reason}`);
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.CLAIM_FAILED,
+                    category: "claim",
+                    level: "error",
+                    message: `Automatic reward claim failed for "${t.name}".`,
+                    questId: q.id,
+                    questName: t.name,
+                    taskType: t.type,
+                    reason,
+                    failure: failureFromError(e, true, retryableHttpStatus(e), reason),
+                });
+            }
         }
     }
 
@@ -476,6 +552,12 @@ function awaitQuestList(runId: number, runRuntime: OrionRuntime, runStores: Stor
     if (getQuestsArray(runStores.QuestStore).length > 0) return Promise.resolve();
 
     logger.info("[Startup] Discord has not sent its quest list yet. Waiting for it before the first cycle.");
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.STARTUP_QUEST_LIST_WAITING,
+        category: "startup",
+        level: "info",
+        message: "Waiting for Discord to provide the current Quest list before the first cycle.",
+    });
     const waitingSince = Date.now();
 
     return new Promise<void>(resolve => {
@@ -491,7 +573,19 @@ function awaitQuestList(runId: number, runRuntime: OrionRuntime, runStores: Stor
             try { runStores.Dispatcher?.unsubscribe?.(QUEST_LIST_EVT, onFetched); }
             catch (e) { debug(logger, `[Startup] Failed to detach the quest list listener: ${(e as any)?.message ?? e}`); }
             const found = getQuestsArray(runStores.QuestStore).length;
-            if (found > 0) logger.info(`[Startup] Quest list arrived after ${Date.now() - waitingSince}ms, ${found} quest(s).`);
+            // Stop/account-switch invalidates this run synchronously. A fetch that settles in the
+            // same turn must still clean up its listener/timers, but it must not publish an event
+            // for a generation Orion no longer owns.
+            if (isRunActive(runId, runRuntime) && found > 0) {
+                const elapsed = Date.now() - waitingSince;
+                logger.info(`[Startup] Quest list arrived after ${elapsed}ms, ${found} quest(s).`);
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.STARTUP_QUEST_LIST_ARRIVED,
+                    category: "startup",
+                    level: "info",
+                    message: `Discord provided ${found} Quest(s) after ${elapsed}ms.`,
+                });
+            }
             resolve();
         };
 
@@ -509,7 +603,18 @@ function awaitQuestList(runId: number, runRuntime: OrionRuntime, runStores: Stor
         }, 250);
 
         timer = setTimeout(() => {
-            logger.warn(`[Startup] Discord had not sent a quest list after ${Math.round(QUEST_LIST_WAIT_MS / 1000)}s. Continuing with what the store holds.`);
+            if (!isRunActive(runId, runRuntime)) {
+                finish();
+                return;
+            }
+            const seconds = Math.round(QUEST_LIST_WAIT_MS / 1000);
+            logger.warn(`[Startup] Discord had not sent a quest list after ${seconds}s. Continuing with what the store holds.`);
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.STARTUP_QUEST_LIST_TIMEOUT,
+                category: "startup",
+                level: "warning",
+                message: `Discord had not provided a Quest list after ${seconds}s; Orion is continuing with current store state.`,
+            });
             finish();
         }, QUEST_LIST_WAIT_MS);
     });
@@ -543,12 +648,25 @@ async function mainLoop(
             }
 
             logger.info(`[Cycle] Starting loop #${loopCount}...`);
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.CYCLE_STARTED,
+                category: "cycle",
+                level: "info",
+                message: `Starting Quest scan cycle #${loopCount}.`,
+            });
 
             const suspendedUntil = questAccessSuspendedUntil(runStores.QuestStore);
             if (suspendedUntil) {
                 const when = suspendedUntil.getTime() === 0 ? "for now" : `until ${suspendedUntil.toLocaleString()}`;
                 logger.error(`[System] Discord has suspended quest access on this account ${when}. Its own client refuses to start a quest in this state, so Orion stops too.`);
                 lastRunOutcome = `Discord has suspended quest access on this account ${when}, so nothing was started.`;
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.SYSTEM_QUEST_ACCESS_SUSPENDED,
+                    category: "system",
+                    level: "error",
+                    message: `Discord has suspended Quest access on this account ${when}; Orion is stopping.`,
+                    reason: lastRunOutcome,
+                });
                 break;
             }
 
@@ -556,6 +674,13 @@ async function mainLoop(
             if (blockedUntil) {
                 logger.error(`[System] Discord has blocked quest enrollment on this account until ${blockedUntil.toLocaleString()}. Stopping instead of retrying.`);
                 lastRunOutcome = `Discord has blocked quest enrollment on this account until ${blockedUntil.toLocaleString()}, so nothing was started.`;
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.SYSTEM_ENROLLMENT_BLOCKED,
+                    category: "system",
+                    level: "error",
+                    message: `Discord has blocked Quest enrollment on this account until ${blockedUntil.toLocaleString()}; Orion is stopping.`,
+                    reason: lastRunOutcome,
+                });
                 break;
             }
 
@@ -580,6 +705,13 @@ async function mainLoop(
                 if (!all.length) {
                     logger.warn("[System] Discord has not given this client a quest list, so there is nothing to run. Reload Discord and try again.");
                     lastRunOutcome = "Discord never sent a quest list to this client, so there was nothing to run.";
+                    emitCompanionEvent({
+                        code: COMPANION_EVENT_CODES.SYSTEM_QUEST_LIST_MISSING,
+                        category: "system",
+                        level: "warning",
+                        message: "Discord did not provide a Quest list, so Orion has nothing to run.",
+                        reason: lastRunOutcome,
+                    });
                     break;
                 }
                 // Saying "all completed" here is how a quest this client skipped, or one that
@@ -588,6 +720,12 @@ async function mainLoop(
                 // it was alive, which cannot tell Orion's work from the user's.
                 const summary = summarizeRun(runRuntime.outcomes);
                 logger.info(`[System] ${summary.line}`);
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.SYSTEM_RUN_SUMMARY,
+                    category: "system",
+                    level: summary.failed > 0 ? "warning" : "info",
+                    message: summary.line,
+                });
                 if (summary.blocked || summary.failed) {
                     const parts: string[] = [];
                     if (summary.finished) parts.push(`${summary.finished} quest(s) finished`);
@@ -625,6 +763,16 @@ async function mainLoop(
                     });
                     if (blocker) {
                         logger.warn(`[Quest] ${blocker} Skipping it for the rest of this run.`);
+                        emitCompanionEvent({
+                            code: COMPANION_EVENT_CODES.QUEST_BLOCKED,
+                            category: "quest",
+                            level: "info",
+                            message: `Orion left "${questName}" out of this run because this client cannot drive it.`,
+                            questId: q.id,
+                            questName,
+                            taskType: detected?.type,
+                            reason: blocker,
+                        });
                         // Marking the quest skipped is the whole point: activeQuests filters on
                         // this set, and without it the same quest comes back every cycle and the
                         // run loops on it until the user pauses (issue #78).
@@ -656,6 +804,16 @@ async function mainLoop(
                     if (!q.userStatus?.enrolledAt && !settings.store.autoEnroll) {
                         if (dashboard.get(q.id)?.status !== "PENDING") {
                             logger.info(`[Enroll] Auto-enroll is off, waiting for you to accept "${t.name}" in Discord.`);
+                            emitCompanionEvent({
+                                code: COMPANION_EVENT_CODES.ENROLL_WAITING,
+                                category: "enroll",
+                                level: "info",
+                                message: `Waiting for you to accept "${t.name}" in Discord.`,
+                                questId: q.id,
+                                questName: t.name,
+                                taskType: t.type,
+                                reason: "Auto-enroll is disabled",
+                            });
                         }
                         setEntry(t.id, { name: t.name, type: t.type, cur: 0, max: t.target, status: "PENDING", actionRequired: "ENROLL" });
                         continue;
@@ -670,6 +828,15 @@ async function mainLoop(
 
                         if (!q.userStatus?.enrolledAt) {
                             logger.info(`[Enroll] Accepting quest: ${t.name}`);
+                            emitCompanionEvent({
+                                code: COMPANION_EVENT_CODES.ENROLL_STARTED,
+                                category: "enroll",
+                                level: "info",
+                                message: `Accepting "${t.name}" through Discord's Quest API.`,
+                                questId: q.id,
+                                questName: t.name,
+                                taskType: t.type,
+                            });
                             try {
                                 await runTraffic.enqueue(`/quests/${q.id}/enroll`, {
                                     location: 11,
@@ -681,14 +848,28 @@ async function mainLoop(
                                 if (!await waitForControlledTaskDelay(runId, runRuntime, t, rnd(800, 1500))) return;
                             } catch (e: any) {
                                 if (!isTaskActive(runId, runRuntime, t)) return;
-                                if (isSkippableQuest(e)) {
+                                const skippable = isSkippableQuest(e);
+                                if (skippable) {
                                     runRuntime.skipped.add(q.id);
                                     runTasks.skipped.add(q.id);
                                     logger.warn(`[Enroll] ${t.name} unavailable (${e.status}). Skipping.`);
                                 } else {
                                     logger.error(`[Enroll] Failed for ${t.name}: ${e?.message}`);
                                 }
-                                return runTasks.failTask(q, t, "Enrollment failed");
+                                const reason = skippable ? `Quest unavailable (HTTP ${e?.status ?? "unknown"})` : "Enrollment failed";
+                                const failure = failureFromError(e, true, retryableHttpStatus(e), reason);
+                                emitCompanionEvent({
+                                    code: COMPANION_EVENT_CODES.ENROLL_FAILED,
+                                    category: "enroll",
+                                    level: skippable ? "warning" : "error",
+                                    message: `Enrollment failed for "${t.name}".`,
+                                    questId: q.id,
+                                    questName: t.name,
+                                    taskType: t.type,
+                                    reason,
+                                    failure,
+                                });
+                                return runTasks.failTask(q, t, "Enrollment failed", failure);
                             }
                         }
 
@@ -716,13 +897,25 @@ async function mainLoop(
                                         || current?.status === "CLAIMED"
                                         || current?.status === "FAILED";
                                     if (!terminal) {
+                                        const reason = "Unexpected task error; see console";
                                         setEntry(q.id, {
                                             name: t.name,
                                             type: t.type,
                                             cur: current?.cur ?? 0,
                                             max: t.target,
                                             status: "FAILED",
-                                            reason: "Unexpected task error; see console",
+                                            reason,
+                                        });
+                                        emitCompanionEvent({
+                                            code: COMPANION_EVENT_CODES.TASK_FAILED,
+                                            category: "task",
+                                            level: "error",
+                                            message: `Task failed unexpectedly for "${t.name}".`,
+                                            questId: q.id,
+                                            questName: t.name,
+                                            taskType: t.type,
+                                            reason,
+                                            failure: failureFromError(error, true, retryableHttpStatus(error), reason),
                                         });
                                         runRuntime.skipped.add(q.id);
                                         runTasks.skipped.add(q.id);
@@ -751,6 +944,12 @@ async function mainLoop(
             const total = queues.video.length + queues.game.length;
             if (total > 0 && isRunActive(runId, runRuntime)) {
                 logger.info(`[Cycle] Processing: ${queues.video.length} videos, ${queues.game.length} games.`);
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.CYCLE_PROCESSING,
+                    category: "cycle",
+                    level: "info",
+                    message: `Cycle #${loopCount} is processing ${queues.video.length} video task(s) and ${queues.game.length} game-lane task(s).`,
+                });
                 await Promise.all([
                     runConcurrent(queues.game, settings.store.gameConcurrency ?? 1, runId, runRuntime),
                     runConcurrent(queues.video, settings.store.videoConcurrency ?? 2, runId, runRuntime),
@@ -761,12 +960,27 @@ async function mainLoop(
 
             if (!isRunActive(runId, runRuntime)) break;
             logger.info(`[Cycle] Loop #${loopCount} complete. Waiting before rescan...`);
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.CYCLE_COMPLETED,
+                category: "cycle",
+                level: "info",
+                message: `Quest scan cycle #${loopCount} completed.`,
+            });
             await sleep(rnd(2500, 4500));
             if (!isRunActive(runId, runRuntime)) break;
             loopCount++;
         } catch (e: any) {
             if (!isRunActive(runId, runRuntime)) break;
-            logger.error(`[Cycle] Error in loop #${loopCount}: ${e?.message ?? e}`);
+            const reason = String(e?.message ?? e);
+            logger.error(`[Cycle] Error in loop #${loopCount}: ${reason}`);
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.CYCLE_FAILED,
+                category: "cycle",
+                level: "error",
+                message: `Quest scan cycle #${loopCount} failed and will be retried.`,
+                reason,
+                failure: failureFromError(e, false, true, reason),
+            });
             await sleep(3000);
             if (!isRunActive(runId, runRuntime)) break;
             loopCount++;
@@ -791,6 +1005,14 @@ export async function startOrion(): Promise<void> {
     if (!startingUserId) {
         logger.error("Cannot start OrionQuests: current Discord user is unavailable.");
         lastRunOutcome = "Discord did not report a logged-in user, so the engine could not start.";
+        emitCompanionEvent({
+            code: COMPANION_EVENT_CODES.ENGINE_START_FAILED,
+            category: "system",
+            level: "error",
+            message: "Orion could not start because Discord did not report a logged-in user.",
+            reason: lastRunOutcome,
+            failure: companionFailure({ terminal: true, retryable: true, reason: lastRunOutcome }),
+        });
         return;
     }
 
@@ -812,7 +1034,14 @@ export async function startOrion(): Promise<void> {
     for (const [id, e] of dashboard) {
         if (e.status !== "RUNNING" && e.status !== "QUEUE" && e.status !== "PAUSED") dashboard.delete(id);
     }
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.ENGINE_STARTED,
+        category: "system",
+        level: "info",
+        message: "Orion engine started.",
+    });
     emitDashboard();
+    if (!isRunActive(runId, runRuntime)) return;
     logger.info("Starting OrionQuests");
 
     try {
@@ -880,7 +1109,16 @@ export async function startOrion(): Promise<void> {
         await mainLoop(runId, runRuntime, runStores, runTasks, runTraffic, runUserId);
     } catch (e: any) {
         if (activeRunId === runId && activeRuntime === runRuntime) {
+            const reason = String(e?.message ?? e);
             logger.error("Fatal:", e);
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.ENGINE_FAILED,
+                category: "system",
+                level: "error",
+                message: "Orion encountered a fatal error after publishing the engine as running.",
+                reason,
+                failure: failureFromError(e, true, retryableHttpStatus(e), reason),
+            });
             runRuntime.running = false;
             RUNTIME.running = false;
         } else {
@@ -894,6 +1132,21 @@ export async function startOrion(): Promise<void> {
 export function stopOrion(): void {
     const runRuntime = activeRuntime;
     if (!RUNTIME.running && !patcher && !stores && !runRuntime) return;
+
+    // Dashboard subscribers run synchronously. If one asks Orion to stop while it is observing
+    // a state publication, mark the run dead immediately so producer liveness guards fire, but
+    // defer destructive cleanup until that producer stack has finished committing its fact/event.
+    if (dashboardDispatchDepth > 0) {
+        if (!stopQueued) {
+            stopQueued = true;
+            queueMicrotask(() => {
+                stopQueued = false;
+                stopOrion();
+            });
+        }
+        return;
+    }
+    stopQueued = false;
 
     activeRunId = 0;
     activeRuntime = null;
@@ -925,15 +1178,30 @@ export function stopOrion(): void {
             dashboard.set(id, { ...e, status: "STOPPED", actionRequired: null });
         }
     }
-    emitDashboard();
 
     setAchievementBypassHook(null);
 
-    try { patcher?.clean(); } catch (e: any) { logger.error("Patcher cleanup threw:", e); }
+    try { patcher?.clean(); }
+    catch (e: any) {
+        failed++;
+        logger.error("Patcher cleanup threw:", e);
+    }
     patcher = null;
     stores = null;
     traffic = null;
     tasks = null;
 
-    logger.info(`Stopped. ${failed > 0 ? `${failed} cleanup(s) threw, see errors above.` : "All cleanups flushed cleanly."}`);
+    const stopMessage = failed > 0 ? `${failed} cleanup(s) threw, see errors above.` : "All cleanups flushed cleanly.";
+    logger.info(`Stopped. ${stopMessage}`);
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.ENGINE_STOPPED,
+        category: "system",
+        level: failed > 0 ? "warning" : "info",
+        message: `Orion engine stopped. ${stopMessage}`,
+        ...(lastRunOutcome ? { reason: lastRunOutcome } : {}),
+    });
+    // Notify control-state consumers only after all old run-owned globals/resources are gone. A
+    // subscriber may synchronously start a new run from this callback without the old stop path
+    // subsequently cleaning or nulling the new run's state.
+    emitDashboard();
 }

--- a/patcher.ts
+++ b/patcher.ts
@@ -23,6 +23,7 @@ import * as DataStore from "@api/DataStore";
 import { getUserSettingLazy } from "@api/UserSettings";
 import { Logger } from "@utils/Logger";
 
+import { COMPANION_EVENT_CODES, emitCompanionEvent } from "./companionEvents";
 import type { FakeGame, Stores } from "./types";
 import { debug } from "./util";
 
@@ -59,8 +60,22 @@ export async function repairSuppressedPresence(): Promise<void> {
         await ShowCurrentGame.updateSetting(true);
         await DataStore.del(SUPPRESSION_KEY);
         logger.info("[Patcher] Previous session ended without restoring your Game Activity setting. Turned it back on.");
+        emitCompanionEvent({
+            code: COMPANION_EVENT_CODES.PATCHER_PRESENCE_RESTORED,
+            category: "patcher",
+            level: "info",
+            message: "Orion restored Discord's Game Activity setting after an unclean previous session.",
+        });
     } catch (e: any) {
-        logger.warn(`[Patcher] Could not restore showCurrentGame from a previous session: ${e?.message}`);
+        const reason = String(e?.message ?? e ?? "unknown error");
+        logger.warn(`[Patcher] Could not restore showCurrentGame from a previous session: ${reason}`);
+        emitCompanionEvent({
+            code: COMPANION_EVENT_CODES.PATCHER_PRESENCE_RESTORE_FAILED,
+            category: "patcher",
+            level: "warning",
+            message: "Orion could not restore Discord's Game Activity setting from the previous session.",
+            reason,
+        });
     }
 }
 

--- a/tasks.ts
+++ b/tasks.ts
@@ -10,6 +10,12 @@
 import { Logger } from "@utils/Logger";
 import type { PluginNative } from "@utils/types";
 
+import {
+    companionFailure,
+    COMPANION_EVENT_CODES,
+    emitCompanionEvent,
+    type CompanionEventFailure,
+} from "./companionEvents";
 import { HeartbeatWatchdog } from "./heartbeatWatchdog";
 import { cleanupCreatedOAuthGrants } from "./oauthLifecycle";
 import type { Patcher } from "./patcher";
@@ -33,25 +39,57 @@ const HEARTBEAT_EVT = "QUESTS_SEND_HEARTBEAT_SUCCESS";
  */
 const HEARTBEAT_FAIL_EVT = "QUESTS_SEND_HEARTBEAT_FAILURE";
 
+interface HeartbeatErrorDetails {
+    text: string;
+    status: number | null;
+    upstreamCode: string | number | null;
+    retryable: boolean;
+}
+
 /**
- * Pull something a user can act on out of a QUESTS_SEND_HEARTBEAT_FAILURE payload. Discord wraps
- * the failure in its own error type, so the useful parts sit at different depths depending on
- * whether the request got a response at all.
+ * Preserve the structured parts of Discord's heartbeat failure before the existing watchdog/log
+ * path flattens them into prose. The prose remains for humans; companion consumers never parse it.
  */
-function describeHeartbeatError(payload: any): string {
+function heartbeatErrorDetails(payload: any): HeartbeatErrorDetails {
     const e = payload?.error ?? payload;
     const parts: string[] = [];
-    const status = e?.status ?? e?.httpStatus;
-    if (status) parts.push(`HTTP ${status}`);
-    const code = e?.body?.code ?? e?.code;
-    if (code != null && code !== status) parts.push(`code ${code}`);
+    const rawStatus = e?.status ?? e?.httpStatus;
+    const status = Number.isFinite(rawStatus) ? Number(rawStatus) : null;
+    if (status != null) parts.push(`HTTP ${status}`);
+    const rawCode = e?.body?.code ?? e?.code;
+    const upstreamCode = typeof rawCode === "string" || typeof rawCode === "number" ? rawCode : null;
+    if (upstreamCode != null && upstreamCode !== status) parts.push(`code ${upstreamCode}`);
     const message = e?.body?.message ?? e?.message;
     if (message) parts.push(String(message));
     if (!parts.length) {
         try { parts.push(JSON.stringify(e).slice(0, 160)); } catch { parts.push(String(e)); }
     }
-    return parts.join(", ") || "no detail";
+    return {
+        text: parts.join(", ") || "no detail",
+        status,
+        upstreamCode,
+        retryable: status == null || status === 408 || status === 429 || status >= 500,
+    };
 }
+
+function errorFailure(
+    error: any,
+    options: { terminal: boolean; retryable: boolean; attempt?: number | null; maxAttempts?: number | null; reason?: string | null; },
+): CompanionEventFailure {
+    const rawStatus = error?.status ?? error?.statusCode ?? error?.httpStatus;
+    const rawCode = error?.body?.code ?? error?.code;
+    const message = options.reason ?? error?.body?.message ?? error?.message ?? null;
+    return companionFailure({
+        terminal: options.terminal,
+        retryable: options.retryable,
+        attempt: options.attempt,
+        maxAttempts: options.maxAttempts,
+        httpStatus: Number.isFinite(rawStatus) ? Number(rawStatus) : null,
+        upstreamCode: typeof rawCode === "string" || typeof rawCode === "number" ? rawCode : null,
+        reason: message == null ? null : String(message),
+    });
+}
+
 const MAX_TIME = 25 * 60 * 1000;
 const HEARTBEAT_GRACE = 90 * 1000;
 const MAX_TASK_FAILURES = 5;
@@ -63,6 +101,15 @@ const BLACKLISTED_QUEST_ID = "1412491570820812933";
 export interface BypassResult {
     ok: boolean;
     reason: string | null;
+    failure?: CompanionEventFailure;
+    disabled?: boolean;
+}
+
+interface AchievementFallbackEvent {
+    level: "info" | "warning";
+    message: string;
+    reason?: string;
+    failure?: CompanionEventFailure;
 }
 
 export interface TaskCallbacks {
@@ -157,6 +204,18 @@ export class TaskRunner {
         });
     }
 
+    private emitTaskStarted(q: Quest, t: TaskInfo, type: TaskType): void {
+        emitCompanionEvent({
+            code: COMPANION_EVENT_CODES.TASK_STARTED,
+            category: "task",
+            level: "info",
+            message: `Started ${type} task for "${t.name}".`,
+            questId: q.id,
+            questName: t.name,
+            taskType: type,
+        });
+    }
+
     appIdFor(cfg: any, keyName: string, legacyAppId?: string): string | null {
         return taskForKey(cfg, keyName)?.applications?.[0]?.id ?? legacyAppId ?? null;
     }
@@ -238,9 +297,20 @@ export class TaskRunner {
         });
     }
 
-    failTask(q: Quest, t: TaskInfo, reason: string): void {
+    failTask(q: Quest, t: TaskInfo, reason: string, failure?: CompanionEventFailure): void {
         if (!this.isTaskActive(t)) return;
         this.cb.onProgress(q.id, { name: t.name, type: t.type, cur: 0, max: t.target, status: "FAILED", reason });
+        emitCompanionEvent({
+            code: COMPANION_EVENT_CODES.TASK_FAILED,
+            category: "task",
+            level: "error",
+            message: `Task failed for "${t.name}".`,
+            questId: q.id,
+            questName: t.name,
+            taskType: t.type,
+            reason,
+            ...(failure ? { failure } : {}),
+        });
         logger.error(`[Task] Aborted "${t.name}": ${reason}`);
         this.skipped.add(q.id);
         // activeQuests reads the skipped set and nothing else, so a quest that died here leaves
@@ -255,6 +325,8 @@ export class TaskRunner {
         let cur = this.readProgress(s, t.keyName);
         let failCount = 0;
         this.cb.onProgress(q.id, { name: t.name, type: "WATCH_VIDEO", cur, max: t.target, status: "RUNNING" });
+        if (!this.isTaskActive(t)) return;
+        this.emitTaskStarted(q, t, "WATCH_VIDEO");
         const startTime = Date.now();
 
         while (cur < t.target && this.isTaskActive(t)) {
@@ -277,9 +349,21 @@ export class TaskRunner {
                 failCount++;
                 if (e?.status && [400, 403, 404, 409, 410].includes(e.status)) {
                     logger.warn(`[Task] Video quest unavailable (HTTP ${e.status}). Skipping.`);
-                    return this.failTask(q, t, `Client Error ${e.status}`);
+                    return this.failTask(q, t, `Client Error ${e.status}`, errorFailure(e, {
+                        terminal: true,
+                        retryable: false,
+                        reason: `Client Error ${e.status}`,
+                    }));
                 }
-                if (failCount >= MAX_TASK_FAILURES) return this.failTask(q, t, "Too many network failures");
+                if (failCount >= MAX_TASK_FAILURES) {
+                    return this.failTask(q, t, "Too many network failures", errorFailure(e, {
+                        terminal: true,
+                        retryable: true,
+                        attempt: failCount,
+                        maxAttempts: MAX_TASK_FAILURES,
+                        reason: "Too many network failures",
+                    }));
+                }
             }
 
             if (!this.isTaskActive(t)) return;
@@ -326,6 +410,8 @@ export class TaskRunner {
             let subscribed = false;
             // Created below, after the spoof is installed, but cleanup can run before that.
             let watchdog: HeartbeatWatchdog | null = null;
+            let heartbeatConsecutiveFailures = 0;
+            let lastHeartbeatFailure: HeartbeatErrorDetails | null = null;
 
             const finish = () => {
                 if (cleaned) return;
@@ -369,6 +455,15 @@ export class TaskRunner {
 
             const seeded = this.readProgress(q.userStatus, key);
             this.cb.onProgress(q.id, { name: t.name, type, cur: seeded, max: t.target, status: "RUNNING" });
+            // Dashboard listeners are synchronous. A listener can pause/stop this exact generation
+            // from the progress publication above, which runs its cleanup before control returns.
+            // Never let that dead continuation recreate a watchdog/subscription or publish started.
+            if (!this.isTaskActive(t)) {
+                finish();
+                resolve();
+                return;
+            }
+            this.emitTaskStarted(q, t, type);
             logger.info(`[Task] Started ${type}: ${gameData.name}`);
 
             safetyTimer = setTimeout(() => {
@@ -386,8 +481,29 @@ export class TaskRunner {
                 onFailureNoted: message => debug(logger, message),
                 onGiveUp: verdict => {
                     if (cleaned || !this.isTaskActive(t)) return;
+                    const latest = lastHeartbeatFailure;
+                    const failure = companionFailure({
+                        terminal: true,
+                        retryable: latest?.retryable ?? false,
+                        attempt: heartbeatConsecutiveFailures || null,
+                        maxAttempts: latest ? MAX_TASK_FAILURES : null,
+                        httpStatus: latest?.status,
+                        upstreamCode: latest?.upstreamCode,
+                        reason: verdict.reason,
+                    });
+                    emitCompanionEvent({
+                        code: COMPANION_EVENT_CODES.HEARTBEAT_GIVE_UP,
+                        category: "network",
+                        level: "error",
+                        message: `Heartbeat reporting stopped for "${t.name}"; the task is giving up.`,
+                        questId: q.id,
+                        questName: t.name,
+                        taskType: type,
+                        reason: verdict.reason,
+                        failure,
+                    });
                     logger.error(verdict.message);
-                    this.failTask(q, t, verdict.reason);
+                    this.failTask(q, t, verdict.reason, failure);
                     finish();
                     resolve();
                 },
@@ -397,6 +513,8 @@ export class TaskRunner {
             const check = (d: any) => {
                 if (!this.isTaskActive(t)) { finish(); resolve(); return; }
                 if (d?.questId !== q.id) return;
+                heartbeatConsecutiveFailures = 0;
+                lastHeartbeatFailure = null;
                 watchdog?.beat();
                 const prog = this.readProgress(d.userStatus, key);
                 this.cb.onProgress(q.id, { name: t.name, type, cur: prog, max: t.target, status: "RUNNING" });
@@ -413,7 +531,29 @@ export class TaskRunner {
             const onFail = (d: any) => {
                 if (!this.isTaskActive(t)) { finish(); resolve(); return; }
                 if (d?.questId !== q.id) return;
-                watchdog?.fail(describeHeartbeatError(d));
+                const details = heartbeatErrorDetails(d);
+                heartbeatConsecutiveFailures++;
+                lastHeartbeatFailure = details;
+                watchdog?.fail(details.text);
+                if (heartbeatConsecutiveFailures >= MAX_TASK_FAILURES || cleaned || !this.isTaskActive(t)) return;
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.HEARTBEAT_FAILURE,
+                    category: "network",
+                    level: "warning",
+                    message: `Discord heartbeat attempt failed for "${t.name}"; Orion is still waiting for the next heartbeat.`,
+                    questId: q.id,
+                    questName: t.name,
+                    taskType: type,
+                    failure: companionFailure({
+                        terminal: false,
+                        retryable: details.retryable,
+                        attempt: heartbeatConsecutiveFailures,
+                        maxAttempts: MAX_TASK_FAILURES,
+                        httpStatus: details.status,
+                        upstreamCode: details.upstreamCode,
+                        reason: details.text,
+                    }),
+                });
             };
 
             try {
@@ -440,6 +580,8 @@ export class TaskRunner {
         let failCount = 0;
         let stalledBeats = 0;
         this.cb.onProgress(q.id, { name: t.name, type: "ACTIVITY", cur, max: t.target, status: "RUNNING" });
+        if (!this.isTaskActive(t)) return;
+        this.emitTaskStarted(q, t, "ACTIVITY");
         const startTime = Date.now();
 
         while (cur < t.target && this.isTaskActive(t)) {
@@ -464,9 +606,21 @@ export class TaskRunner {
                 failCount++;
                 if (e?.status && [400, 403, 404, 409, 410].includes(e.status)) {
                     logger.warn(`[Task] Activity quest unavailable (HTTP ${e.status}). Skipping.`);
-                    return this.failTask(q, t, `Client Error ${e.status}`);
+                    return this.failTask(q, t, `Client Error ${e.status}`, errorFailure(e, {
+                        terminal: true,
+                        retryable: false,
+                        reason: `Client Error ${e.status}`,
+                    }));
                 }
-                if (failCount >= MAX_TASK_FAILURES) return this.failTask(q, t, "Too many network failures");
+                if (failCount >= MAX_TASK_FAILURES) {
+                    return this.failTask(q, t, "Too many network failures", errorFailure(e, {
+                        terminal: true,
+                        retryable: true,
+                        attempt: failCount,
+                        maxAttempts: MAX_TASK_FAILURES,
+                        reason: "Too many network failures",
+                    }));
+                }
             }
             if (!this.isTaskActive(t)) return;
             if (Date.now() - startTime > MAX_TIME) return this.failTask(q, t, "Timeout exceeded");
@@ -476,24 +630,67 @@ export class TaskRunner {
         if (this.isTaskActive(t) && cur >= t.target) await this.cb.onComplete(q, t);
     }
 
-    async bypassAchievement(q: Quest, t: TaskInfo): Promise<BypassResult> {
+    async bypassAchievement(q: Quest, t: TaskInfo, fallback?: AchievementFallbackEvent): Promise<BypassResult> {
         let reason: string | null = null;
         if (!this.isTaskActive(t)) return { ok: false, reason };
+
+        // A fallback event means Orion is actually taking the OAuth branch. Checking consent here,
+        // before publishing it or validating bypass-only metadata, prevents companions from being
+        // told that a fallback will run when the user explicitly disabled that path.
+        if (!settings.store.achievementBypass) {
+            reason = "Achievement bypass is off in settings";
+            logger.info(`[Bypass] Achievement OAuth bypass is off in settings; skipping "${t.name}". Enable it in OrionQuests settings if you want it.`);
+            return { ok: false, reason, disabled: true };
+        }
+
+        if (fallback) {
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.ACHIEVEMENT_FALLBACK,
+                category: "achievement",
+                level: fallback.level,
+                message: fallback.message,
+                questId: q.id,
+                questName: t.name,
+                taskType: t.type,
+                ...(fallback.reason ? { reason: fallback.reason } : {}),
+                ...(fallback.failure ? { failure: fallback.failure } : {}),
+            });
+        }
 
         const accountId = this.stores.UserStore?.getCurrentUser?.()?.id ?? null;
         const appId = String(t.appId || q.config?.application?.id || "");
         if (!appId) {
             reason = "this quest carries no application id, so there is nothing to authorize against";
-            return { ok: false, reason };
-        }
-        if (!settings.store.achievementBypass) {
-            logger.info(`[Bypass] Achievement OAuth bypass is off in settings; skipping "${t.name}". Enable it in OrionQuests settings if you want it.`);
-            return { ok: false, reason };
+            const failure = companionFailure({ terminal: true, retryable: false, reason });
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.BYPASS_FAILED,
+                category: "bypass",
+                level: "warning",
+                message: `Discord Says bypass could not start for "${t.name}".`,
+                questId: q.id,
+                questName: t.name,
+                taskType: t.type,
+                reason,
+                failure,
+            });
+            return { ok: false, reason, failure };
         }
         if (!/^\d+$/.test(appId)) {
             reason = `the quest's application id ("${appId}") is not numeric, so it was refused before any request went out`;
+            const failure = companionFailure({ terminal: true, retryable: false, reason });
             logger.warn(`[Bypass] Refusing non-numeric appId "${appId}".`);
-            return { ok: false, reason };
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.BYPASS_FAILED,
+                category: "bypass",
+                level: "warning",
+                message: `Discord Says bypass refused invalid application metadata for "${t.name}".`,
+                questId: q.id,
+                questName: t.name,
+                taskType: t.type,
+                reason,
+                failure,
+            });
+            return { ok: false, reason, failure };
         }
 
         let preGrantIds: Set<string> | undefined;
@@ -505,13 +702,35 @@ export class TaskRunner {
                 .map((tk: any) => tk.id));
         } catch (e: any) {
             if (!this.isTaskActive(t)) return { ok: false, reason };
+            reason = "Orion could not snapshot existing OAuth grants, so the bypass was aborted before authorization";
+            const failure = errorFailure(e, { terminal: true, retryable: false, reason });
             logger.warn(`[Bypass] Couldn't snapshot existing grants; aborting so we never leave an un-revocable authorization: ${e?.message}`);
-            return { ok: false, reason };
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.BYPASS_FAILED,
+                category: "bypass",
+                level: "warning",
+                message: `Discord Says bypass stopped before authorization for "${t.name}".`,
+                questId: q.id,
+                questName: t.name,
+                taskType: t.type,
+                reason,
+                failure,
+            });
+            return { ok: false, reason, failure };
         }
 
         try {
             if (!this.isTaskActive(t)) return { ok: false, reason };
             logger.info(`[Bypass] Trying Discord Says auth flow for "${t.name}"...`);
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.BYPASS_STARTED,
+                category: "bypass",
+                level: "info",
+                message: `Discord Says bypass started for "${t.name}".`,
+                questId: q.id,
+                questName: t.name,
+                taskType: t.type,
+            });
 
             const authRes: any = await this.stores.API.post({
                 url: "/oauth2/authorize",
@@ -544,7 +763,11 @@ export class TaskRunner {
             if (!this.isTaskActive(t)) return { ok: false, reason };
             const dsAuthRes = await Native.discordsaysAuthorize({ appId, questId: q.id, authCode, referrer });
             if (!this.isTaskActive(t)) return { ok: false, reason };
-            if (!dsAuthRes.ok) throw new Error(`discordsays authorize ${dsAuthRes.status}`);
+            if (!dsAuthRes.ok) {
+                const error: any = new Error(`discordsays authorize ${dsAuthRes.status}`);
+                error.status = dsAuthRes.status;
+                throw error;
+            }
             let dsToken: string | undefined;
             try { dsToken = (JSON.parse(dsAuthRes.body) as { token?: string }).token; }
             catch { throw new Error("discordsays returned non-JSON: " + String(dsAuthRes.body).slice(0, 120)); }
@@ -553,17 +776,42 @@ export class TaskRunner {
             if (!this.isTaskActive(t)) return { ok: false, reason };
             const progRes = await Native.discordsaysProgress({ appId, questId: q.id, token: dsToken, target: t.target, referrer });
             if (!this.isTaskActive(t)) return { ok: false, reason };
-            if (!progRes.ok) throw new Error(`discordsays progress ${progRes.status}`);
+            if (!progRes.ok) {
+                const error: any = new Error(`discordsays progress ${progRes.status}`);
+                error.status = progRes.status;
+                throw error;
+            }
 
             logger.info(`[Bypass] Success. "${t.name}" completed via Discord Says.`);
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.BYPASS_SUCCEEDED,
+                category: "bypass",
+                level: "success",
+                message: `Discord Says bypass completed "${t.name}".`,
+                questId: q.id,
+                questName: t.name,
+                taskType: t.type,
+            });
             return { ok: true, reason: null };
         } catch (e: any) {
             if (!this.isTaskActive(t)) return { ok: false, reason };
-            const code = e?.body?.code;
+            const code = e?.body?.code ?? e?.code;
             if (code === 50165) {
                 reason = "the activity is age-gated or delisted, so Discord refuses the proxy ticket on this account";
+                const failure = errorFailure(e, { terminal: true, retryable: false, reason });
                 logger.warn(`[Bypass] "${t.name}" can't be launched (age-gated or delisted). Discord blocks the proxy ticket, so there is nothing we can do.`);
-                return { ok: false, reason };
+                emitCompanionEvent({
+                    code: COMPANION_EVENT_CODES.BYPASS_FAILED,
+                    category: "bypass",
+                    level: "warning",
+                    message: `Discord Says bypass is unavailable for "${t.name}" on this account.`,
+                    questId: q.id,
+                    questName: t.name,
+                    taskType: t.type,
+                    reason,
+                    failure,
+                });
+                return { ok: false, reason, failure };
             }
             const parts: string[] = [];
             if (e?.status) parts.push(`HTTP ${e.status}`);
@@ -573,8 +821,24 @@ export class TaskRunner {
             else if (typeof e === "string") parts.push(e);
             else if (e) { try { parts.push(JSON.stringify(e).slice(0, 200)); } catch { parts.push(String(e)); } }
             reason = `the Discord Says bypass failed (${parts.join(", ") || "unknown error"})`;
+            const failure = errorFailure(e, {
+                terminal: true,
+                retryable: e?.status === 408 || e?.status === 429 || e?.status >= 500,
+                reason,
+            });
             logger.warn(`[Bypass] Failed: ${parts.join(", ") || "unknown"}`);
-            return { ok: false, reason };
+            emitCompanionEvent({
+                code: COMPANION_EVENT_CODES.BYPASS_FAILED,
+                category: "bypass",
+                level: "warning",
+                message: `Discord Says bypass failed for "${t.name}".`,
+                questId: q.id,
+                questName: t.name,
+                taskType: t.type,
+                reason,
+                failure,
+            });
+            return { ok: false, reason, failure };
         } finally {
             // Compensating cleanup is intentionally allowed after task cancellation because a
             // request already on the wire may have created a grant. Account identity is checked
@@ -610,7 +874,10 @@ export class TaskRunner {
 
         let cur = this.readProgress(q.userStatus, t.keyName);
         this.cb.onProgress(q.id, { name: t.name, type: "ACHIEVEMENT", cur, max: t.target, status: "RUNNING" });
+        if (!this.isTaskActive(t)) return;
+        this.emitTaskStarted(q, t, "ACHIEVEMENT");
 
+        let fallback: AchievementFallbackEvent | undefined;
         const key = this.streamKey();
         if (key) {
             const beat = { stream_key: key, application_id: String(t.appId || ""), terminal: false };
@@ -636,11 +903,33 @@ export class TaskRunner {
                     if (!this.isTaskActive(t)) return;
                     failCount++;
                     if (e?.status && [400, 403, 404, 409, 410].includes(e.status)) {
-                        logger.warn(`[Achievement] Heartbeat rejected (HTTP ${e.status}). Falling back to bypass.`);
+                        logger.warn(`[Achievement] Heartbeat rejected (HTTP ${e.status}).`);
+                        fallback = {
+                            level: "warning",
+                            message: `Achievement heartbeat was rejected for "${t.name}"; Orion will try the Discord Says bypass.`,
+                            failure: errorFailure(e, {
+                                terminal: false,
+                                retryable: false,
+                                attempt: failCount,
+                                maxAttempts: failCount,
+                                reason: `Heartbeat rejected (HTTP ${e.status})`,
+                            }),
+                        };
                         break;
                     }
                     if (failCount >= MAX_TASK_FAILURES) {
-                        logger.warn(`[Achievement] Too many failures. Falling back to bypass.`);
+                        logger.warn("[Achievement] Too many heartbeat failures.");
+                        fallback = {
+                            level: "warning",
+                            message: `Achievement heartbeat retries were exhausted for "${t.name}"; Orion will try the Discord Says bypass.`,
+                            failure: errorFailure(e, {
+                                terminal: false,
+                                retryable: true,
+                                attempt: failCount,
+                                maxAttempts: MAX_TASK_FAILURES,
+                                reason: "Achievement heartbeat attempts exhausted",
+                            }),
+                        };
                         break;
                     }
                 }
@@ -648,20 +937,26 @@ export class TaskRunner {
             }
 
             if (cur >= t.target && this.isTaskActive(t)) return this.cb.onComplete(q, t);
+        } else {
+            fallback = {
+                level: "info",
+                message: `No voice-channel stream key was available for "${t.name}"; Orion will try the Discord Says bypass.`,
+                reason: "No voice channel stream key available for the heartbeat path",
+            };
         }
 
         if (!this.isTaskActive(t)) return;
-        const bypass = await this.bypassAchievement(q, t);
+        const bypass = await this.bypassAchievement(q, t, fallback);
         if (!this.isTaskActive(t)) return;
         if (bypass.ok) return this.cb.onComplete(q, t);
 
-        if (!settings.store.achievementBypass) {
+        if (bypass.disabled) {
             this.consentSkipped.add(q.id);
-            return this.failTask(q, t, "Achievement bypass is off in settings");
+            return this.failTask(q, t, bypass.reason ?? "Achievement bypass is off in settings");
         }
 
         logger.warn(`[Task] Skipping "${t.name}". No auto-completion path worked (heartbeat rejected, bypass blocked). Likely age-gated/delisted on your account.`);
-        return this.failTask(q, t, bypass.reason ?? "no auto-completion path worked");
+        return this.failTask(q, t, bypass.reason ?? "no auto-completion path worked", bypass.failure);
     }
 
     retryConsentSkipped(): number {

--- a/tests/companionEvents.test.ts
+++ b/tests/companionEvents.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+    clearCompanionEventListeners,
+    companionFailure,
+    COMPANION_EVENT_CODES,
+    COMPANION_EVENT_CODE_STABILITY,
+    emitCompanionEvent,
+    sanitizeCompanionText,
+    subscribeCompanionEvents,
+    type CompanionEvent,
+} from "../companionEvents";
+
+const flushCompanionEvents = (): Promise<void> => new Promise(resolve => queueMicrotask(resolve));
+
+test.afterEach(() => clearCompanionEventListeners());
+
+test("companion events deliver immutable structured data in subscription order", async () => {
+    const seen: Array<{ listener: string; event: CompanionEvent; }> = [];
+    subscribeCompanionEvents(event => seen.push({ listener: "first", event }));
+    subscribeCompanionEvents(event => seen.push({ listener: "second", event }));
+
+    emitCompanionEvent({
+        timestamp: 1234,
+        code: COMPANION_EVENT_CODES.TASK_FAILED,
+        category: "task",
+        level: "error",
+        message: "Task failed",
+        questId: "quest-1",
+        questName: "Example Quest",
+        taskType: "GAME",
+        failure: companionFailure({
+            terminal: true,
+            retryable: true,
+            attempt: 5,
+            maxAttempts: 5,
+            httpStatus: 503,
+            upstreamCode: 12345,
+            reason: "Too many network failures",
+        }),
+    });
+    await flushCompanionEvents();
+
+    assert.deepEqual(seen.map(row => row.listener), ["first", "second"]);
+    assert.equal(seen[0].event.timestamp, 1234);
+    assert.equal(seen[0].event.failure?.terminal, true);
+    assert.equal(seen[0].event.failure?.retryable, true);
+    assert.equal(seen[0].event.failure?.httpStatus, 503);
+    assert.equal(seen[0].event.failure?.upstreamCode, 12345);
+    assert.equal(Object.isFrozen(seen[0].event), true);
+    assert.equal(Object.isFrozen(seen[0].event.failure), true);
+    assert.equal(seen[0].event, seen[1].event);
+});
+
+test("event observers cannot synchronously re-enter the producer stack", async () => {
+    let delivered = false;
+    subscribeCompanionEvents(() => { delivered = true; });
+
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.ENGINE_STARTED,
+        category: "system",
+        level: "info",
+        message: "started",
+    });
+
+    assert.equal(delivered, false, "Delivery must be deferred until the producer transition returns.");
+    await flushCompanionEvents();
+    assert.equal(delivered, true);
+});
+
+test("task.failed always carries terminal failure metadata even without transport details", async () => {
+    const seen: CompanionEvent[] = [];
+    subscribeCompanionEvents(event => seen.push(event));
+
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.TASK_FAILED,
+        category: "task",
+        level: "error",
+        message: "Task timed out",
+        questId: "quest-timeout",
+        reason: "Timeout exceeded",
+    });
+    await flushCompanionEvents();
+
+    assert.equal(seen.length, 1);
+    const event = seen[0]!;
+    assert.equal(event.failure?.terminal, true);
+    assert.equal(event.failure?.retryable, false);
+    assert.equal(event.failure?.attempt, null);
+    assert.equal(event.failure?.maxAttempts, null);
+    assert.equal(event.failure?.httpStatus, null);
+    assert.equal(event.failure?.upstreamCode, null);
+    assert.equal(event.failure?.reason, "Timeout exceeded");
+});
+
+test("one throwing listener cannot block later listeners", async () => {
+    const originalError = console.error;
+    const logged: unknown[][] = [];
+    console.error = (...args: unknown[]) => { logged.push(args); };
+
+    try {
+        let delivered = 0;
+        subscribeCompanionEvents(() => { throw new Error("listener exploded"); });
+        subscribeCompanionEvents(() => { delivered++; });
+
+        emitCompanionEvent({
+            code: COMPANION_EVENT_CODES.ENGINE_STARTED,
+            category: "system",
+            level: "info",
+            message: "Engine started",
+        });
+        await flushCompanionEvents();
+
+        assert.equal(delivered, 1);
+        assert.equal(logged.length, 1);
+    } finally {
+        console.error = originalError;
+    }
+});
+
+test("unsubscribe is idempotent and only affects later emissions", async () => {
+    let calls = 0;
+    const unsubscribe = subscribeCompanionEvents(() => { calls++; });
+
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.ENGINE_STARTED,
+        category: "system",
+        level: "info",
+        message: "started",
+    });
+    unsubscribe();
+    unsubscribe();
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.ENGINE_STOPPED,
+        category: "system",
+        level: "info",
+        message: "stopped",
+    });
+    await flushCompanionEvents();
+
+    assert.equal(calls, 1, "A listener receives the event whose emission already captured it, but no later emissions.");
+});
+
+test("failure normalization rejects invalid counters/status without inventing values", () => {
+    const failure = companionFailure({
+        terminal: false,
+        retryable: true,
+        attempt: 0,
+        maxAttempts: Number.NaN,
+        httpStatus: 999,
+        upstreamCode: null,
+        reason: "",
+    });
+
+    assert.deepEqual(failure, {
+        terminal: false,
+        retryable: true,
+        attempt: null,
+        maxAttempts: null,
+        httpStatus: null,
+        upstreamCode: null,
+        reason: null,
+    });
+
+    const inconsistent = companionFailure({
+        terminal: true,
+        retryable: false,
+        attempt: 3,
+        maxAttempts: 1,
+    });
+    assert.equal(inconsistent.attempt, 3);
+    assert.equal(inconsistent.maxAttempts, null, "An impossible maxAttempts < attempt pair must not be published.");
+});
+
+test("known credential shapes are redacted before companion delivery", async () => {
+    const seen: CompanionEvent[] = [];
+    subscribeCompanionEvents(event => seen.push(event));
+
+    const failure = companionFailure({
+        terminal: true,
+        retryable: false,
+        upstreamCode: "access_token=code-secret",
+        reason: "Authorization: Bearer secret-token proxy_ticket=proxy-secret",
+    });
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.BYPASS_FAILED,
+        category: "bypass",
+        level: "error",
+        message: "request failed https://example.invalid/?code=oauth-secret&ticket=ticket-secret",
+        reason: "cookie=session-secret access_token=access-secret",
+        failure,
+    });
+    await flushCompanionEvents();
+
+    assert.equal(seen.length, 1);
+    const serialized = JSON.stringify(seen[0]);
+    for (const secret of ["secret-token", "proxy-secret", "oauth-secret", "ticket-secret", "session-secret", "access-secret", "code-secret"]) {
+        assert.doesNotMatch(serialized, new RegExp(secret));
+    }
+    assert.match(serialized, /\[REDACTED\]/);
+    assert.equal(sanitizeCompanionText("auth code=my-code"), "auth code=[REDACTED]");
+    assert.equal(sanitizeCompanionText("token=plain-token ticket=plain-ticket"), "token=[REDACTED] ticket=[REDACTED]");
+
+    const json = sanitizeCompanionText(JSON.stringify({
+        access_token: "json-access-secret",
+        authCode: "json-auth-secret",
+        proxyTicket: "json-ticket-secret",
+        cookie: "json-cookie-secret",
+    }));
+    for (const secret of ["json-access-secret", "json-auth-secret", "json-ticket-secret", "json-cookie-secret"]) {
+        assert.doesNotMatch(json, new RegExp(secret));
+    }
+});
+
+test("every published code declares whether its contract is stable or provisional", () => {
+    const codes = Object.values(COMPANION_EVENT_CODES).sort();
+    const declared = Object.keys(COMPANION_EVENT_CODE_STABILITY).sort();
+    assert.deepEqual(declared, codes);
+    assert.notEqual(COMPANION_EVENT_CODES.ENGINE_START_FAILED, COMPANION_EVENT_CODES.ENGINE_FAILED,
+        "A failed start and a fatal failure after engine.started are distinct lifecycle facts.");
+    assert.equal(COMPANION_EVENT_CODE_STABILITY[COMPANION_EVENT_CODES.ENGINE_START_FAILED], "stable");
+    assert.equal(COMPANION_EVENT_CODE_STABILITY[COMPANION_EVENT_CODES.ENGINE_FAILED], "stable");
+    assert.equal(COMPANION_EVENT_CODE_STABILITY[COMPANION_EVENT_CODES.TASK_FAILED], "stable");
+    assert.equal(COMPANION_EVENT_CODE_STABILITY[COMPANION_EVENT_CODES.CYCLE_STARTED], "provisional");
+});

--- a/tests/traffic.test.ts
+++ b/tests/traffic.test.ts
@@ -7,6 +7,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import {
+    clearCompanionEventListeners,
+    COMPANION_EVENT_CODES,
+    subscribeCompanionEvents,
+    type CompanionEvent,
+} from "../companionEvents";
 import { Traffic } from "../traffic";
 
 function deferred<T = void>() {
@@ -21,6 +27,8 @@ const silentLogger = {
     error() { },
     debug() { },
 };
+
+test.afterEach(() => clearCompanionEventListeners());
 
 test("a queued task request aborts synchronously and never reaches API.post", async () => {
     const first = deferred<void>();
@@ -172,4 +180,118 @@ test("a stale liveness predicate still blocks a queued request without an AbortS
     await firstRequest;
     await assert.rejects(secondRequest, (error: any) => error?.name === "AbortError");
     assert.deepEqual(calls, ["/first"]);
+});
+
+test("a retry event reports the actual 1-based request attempt and total attempt budget", async () => {
+    const controller = new AbortController();
+    const seen = deferred<CompanionEvent>();
+    subscribeCompanionEvents(event => {
+        if (event.code === COMPANION_EVENT_CODES.NETWORK_RETRY) seen.resolve(event);
+    });
+
+    const API = {
+        post: async () => {
+            throw {
+                status: 429,
+                body: {
+                    retry_after: 60,
+                    global: false,
+                    code: 130000,
+                    message: "You are being rate limited.",
+                },
+            };
+        },
+    };
+    const traffic = new Traffic(API, () => true, silentLogger);
+    const request = traffic.enqueue("/quests/123456789/retry", {}, () => true, controller.signal);
+
+    const event = await seen.promise;
+    assert.equal(event.questId, "123456789");
+    assert.equal(event.failure?.terminal, false);
+    assert.equal(event.failure?.retryable, true);
+    assert.equal(event.failure?.attempt, 1);
+    assert.equal(event.failure?.maxAttempts, 4);
+    assert.equal(event.failure?.httpStatus, 429);
+    assert.equal(event.failure?.upstreamCode, 130000);
+
+    controller.abort();
+    await assert.rejects(request, (error: any) => error?.name === "AbortError");
+});
+
+test("a non-retryable request failure keeps upstream status/code separate from prose", async () => {
+    const events: CompanionEvent[] = [];
+    subscribeCompanionEvents(event => events.push(event));
+    const error = {
+        status: 403,
+        body: { code: 50165, message: "Application unavailable" },
+    };
+    const API = { post: async () => { throw error; } };
+    const traffic = new Traffic(API, () => true, silentLogger);
+
+    await assert.rejects(traffic.enqueue("/quests/987654321/enroll", {}), candidate => candidate === error);
+
+    assert.equal(events.length, 1);
+    const event = events[0];
+    assert.equal(event.code, COMPANION_EVENT_CODES.NETWORK_FAILED);
+    assert.equal(event.questId, "987654321");
+    assert.equal(event.failure?.terminal, true);
+    assert.equal(event.failure?.retryable, false);
+    assert.equal(event.failure?.attempt, 1);
+    assert.equal(event.failure?.maxAttempts, 1);
+    assert.equal(event.failure?.httpStatus, 403);
+    assert.equal(event.failure?.upstreamCode, 50165);
+    assert.equal(event.failure?.reason, "Application unavailable");
+});
+
+test("a later non-retryable response terminates on its real attempt without an impossible budget", async () => {
+    const events: CompanionEvent[] = [];
+    subscribeCompanionEvents(event => events.push(event));
+    let attempts = 0;
+    const terminal = { status: 400, body: { code: 40001, message: "Bad request" } };
+    const API = {
+        post: async () => {
+            attempts++;
+            if (attempts === 1) {
+                throw { status: 429, body: { retry_after: 0, global: true, code: 130000, message: "Retry once" } };
+            }
+            throw terminal;
+        },
+    };
+    const traffic = new Traffic(API, () => true, silentLogger);
+
+    await assert.rejects(traffic.enqueue("/quests/24681012/enroll", {}), candidate => candidate === terminal);
+
+    const failed = events.find(event => event.code === COMPANION_EVENT_CODES.NETWORK_FAILED);
+    assert.ok(failed);
+    assert.equal(attempts, 2);
+    assert.equal(failed.failure?.terminal, true);
+    assert.equal(failed.failure?.retryable, false);
+    assert.equal(failed.failure?.attempt, 2);
+    assert.equal(failed.failure?.maxAttempts, 2);
+    assert.equal(failed.failure?.httpStatus, 400);
+    assert.equal(failed.failure?.upstreamCode, 40001);
+});
+
+test("task cancellation does not masquerade as a network failure event", async () => {
+    const first = deferred<void>();
+    const events: CompanionEvent[] = [];
+    subscribeCompanionEvents(event => events.push(event));
+    const controller = new AbortController();
+    const API = {
+        post: async ({ url }: { url: string; }) => {
+            if (url === "/hold") await first.promise;
+            return { body: {} };
+        },
+    };
+    const traffic = new Traffic(API, () => true, silentLogger);
+
+    const holding = traffic.enqueue("/hold", {});
+    const cancelled = traffic.enqueue("/quests/111222333/progress", {}, () => true, controller.signal);
+    controller.abort();
+    await assert.rejects(cancelled, (error: any) => error?.name === "AbortError");
+    assert.equal(events.length, 0);
+
+    first.resolve();
+    await holding;
+    assert.equal(events.length, 0);
 });

--- a/tools/orion-devbuild-installer/installer-common.ps1
+++ b/tools/orion-devbuild-installer/installer-common.ps1
@@ -374,21 +374,96 @@ function Start-DiscordFlavors {
     return @($failed | Select-Object -Unique)
 }
 
+function Get-GitCheckoutFingerprint {
+    <#
+      Content-aware snapshot for a destructive companion decision.
+
+      `git status --short` is intentionally not enough: editing the same already-dirty file keeps
+      exactly the same status line, and changing an existing untracked file keeps the same path.
+      Capture the index plus the bytes of every tracked and non-ignored untracked file instead.
+      Ignored files are excluded because `git clean -fd` deliberately preserves them.
+    #>
+    param([Parameter(Mandatory)][string]$Path)
+
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $indexState = (& git -C $Path ls-files --stage -z 2>$null) -join ''
+        if ($LASTEXITCODE -ne 0) { return $null }
+        $trackedRaw = (& git -C $Path ls-files -z 2>$null) -join ''
+        if ($LASTEXITCODE -ne 0) { return $null }
+        $untrackedRaw = (& git -C $Path ls-files --others --exclude-standard -z 2>$null) -join ''
+        if ($LASTEXITCODE -ne 0) { return $null }
+
+        $trackedPaths = @($trackedRaw -split [char]0 | Where-Object { $_.Length -gt 0 })
+        $untrackedPaths = @($untrackedRaw -split [char]0 | Where-Object { $_.Length -gt 0 })
+        $rows = New-Object System.Collections.Generic.List[string]
+        $utf8 = New-Object System.Text.UTF8Encoding($false)
+
+        foreach ($kindAndPath in @(
+            @($trackedPaths | ForEach-Object { [pscustomobject]@{ Kind = 'T'; Relative = [string]$_ } }),
+            @($untrackedPaths | ForEach-Object { [pscustomobject]@{ Kind = 'U'; Relative = [string]$_ } })
+        )) {
+            foreach ($entry in @($kindAndPath)) {
+                $relative = [string]$entry.Relative
+                $pathToken = [Convert]::ToBase64String($utf8.GetBytes($relative))
+                $full = Join-Path $Path $relative
+                if (Test-Path -LiteralPath $full -PathType Leaf) {
+                    try {
+                        $hash = (Get-FileHash -LiteralPath $full -Algorithm SHA256 -ErrorAction Stop).Hash.ToLowerInvariant()
+                        $rows.Add("$($entry.Kind):$pathToken:F:$hash")
+                    } catch {
+                        return $null
+                    }
+                } elseif (Test-Path -LiteralPath $full -PathType Container) {
+                    # Gitlinks/submodules are directories in the parent worktree. The index state
+                    # above carries their gitlink SHA; the marker keeps path/type changes visible.
+                    $rows.Add("$($entry.Kind):$pathToken:D")
+                } else {
+                    $rows.Add("$($entry.Kind):$pathToken:MISSING")
+                }
+            }
+        }
+
+        $orderedRows = @($rows | Sort-Object)
+        $indexToken = [Convert]::ToBase64String($utf8.GetBytes($indexState))
+        $payload = "index=$indexToken`n" + ($orderedRows -join "`n")
+        $sha = [Security.Cryptography.SHA256]::Create()
+        try {
+            $digest = $sha.ComputeHash($utf8.GetBytes($payload))
+            return ([BitConverter]::ToString($digest)).Replace('-', '').ToLowerInvariant()
+        } finally {
+            $sha.Dispose()
+        }
+    } finally {
+        $ErrorActionPreference = $prev
+    }
+}
+
 function Update-CompanionUserplugins {
     <#
-      Fast-forward every other git-checked-out userplugin sitting beside orionQuests.
+      Update every other git-checked-out userplugin sitting beside orionQuests.
 
-      People run companion plugins in this checkout, QuestUI being the one this came from, and
-      updating one meant knowing the git command and running it by hand. UPDATE.cmd already
-      rebuilds the whole tree, so the plugins it compiles in may as well be current.
+      A normal behind checkout still fast-forwards. The extra case handled here is a companion
+      whose upstream rewrote history after the user cloned it. Auto-recovery is deliberately
+      narrow: the checkout must have been clean with HEAD exactly equal to its pre-fetch upstream,
+      and that same proof is revalidated immediately before reset --hard. Local edits, untracked
+      files, staged changes, or local commits are never reset automatically.
 
-      --ff-only on purpose, never a reset. This touches somebody else's repository, so a plugin
-      with local edits or a diverged branch is reported and left exactly as it was rather than
-      quietly discarded. A pull that fails is not fatal either: the build still runs with the
-      checkout that is already on disk, and the transactional build is what decides whether the
-      result ships.
+      A local-ahead checkout that already contains the fetched upstream is already current, even
+      when its worktree is dirty, so it is left alone without asking a destructive question.
+
+      Interactive callers may supply DecisionProvider. It receives one context object and returns
+      "keep" or "discard". With no provider the safe default is keep. Before honoring Discard, the
+      checkout HEAD, upstream ref and a content-aware local-work fingerprint are revalidated so
+      consent for one snapshot cannot discard bytes that changed while the decision was pending.
+      Discard resets tracked state and removes non-ignored untracked files; ignored files are never
+      cleaned.
     #>
-    param([Parameter(Mandatory)][string]$InstallDir)
+    param(
+        [Parameter(Mandatory)][string]$InstallDir,
+        [scriptblock]$DecisionProvider
+    )
 
     $root = Join-Path $InstallDir 'src\userplugins'
     $results = @()
@@ -402,20 +477,273 @@ function Update-CompanionUserplugins {
             continue
         }
 
-        $before = (& git -C $dir.FullName rev-parse HEAD 2>$null)
+        $before = ((& git -C $dir.FullName rev-parse HEAD 2>$null) -join '').Trim()
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($before)) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'could not read checkout HEAD' }
+            continue
+        }
+
+        $upstreamRef = ((& git -C $dir.FullName rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>$null) -join '').Trim()
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($upstreamRef)) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'current branch has no tracked upstream' }
+            continue
+        }
+
+        $beforeUpstream = ((& git -C $dir.FullName rev-parse '@{u}' 2>$null) -join '').Trim()
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($beforeUpstream)) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = "could not resolve tracked upstream $upstreamRef" }
+            continue
+        }
+
+        $changesBeforeFetch = @(& git -C $dir.FullName status --short --untracked-files=all 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($LASTEXITCODE -ne 0) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'could not inspect local changes' }
+            continue
+        }
+
         $prev = $ErrorActionPreference
         $ErrorActionPreference = 'Continue'
-        $output = (& git -C $dir.FullName pull --ff-only 2>&1) -join ' '
-        $code = $LASTEXITCODE
+        $fetchOutput = (& git -C $dir.FullName fetch --quiet 2>&1) -join ' '
+        $fetchCode = $LASTEXITCODE
         $ErrorActionPreference = $prev
-        $after = (& git -C $dir.FullName rev-parse HEAD 2>$null)
+        if ($fetchCode -ne 0) {
+            $detail = $fetchOutput.Trim()
+            if ([string]::IsNullOrWhiteSpace($detail)) { $detail = 'git fetch failed' }
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = $detail }
+            continue
+        }
 
-        if ($code -ne 0) {
-            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = $output.Trim() }
-        } elseif ($before -ne $after) {
-            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'updated'; Detail = "$($before.Substring(0, 7)) -> $($after.Substring(0, 7))" }
-        } else {
-            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'current'; Detail = $after.Substring(0, 7) }
+        $afterUpstream = ((& git -C $dir.FullName rev-parse '@{u}' 2>$null) -join '').Trim()
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($afterUpstream)) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = "tracked upstream $upstreamRef disappeared after fetch" }
+            continue
+        }
+
+        # Everything destructive below reasons from a fresh post-fetch snapshot, not the status
+        # captured before a potentially slow network operation.
+        $currentHead = ((& git -C $dir.FullName rev-parse HEAD 2>$null) -join '').Trim()
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($currentHead)) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'could not re-read checkout HEAD after fetch' }
+            continue
+        }
+        $changes = @(& git -C $dir.FullName status --short --untracked-files=all 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($LASTEXITCODE -ne 0) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'could not re-read local changes after fetch' }
+            continue
+        }
+
+        $shortCurrent = if ($currentHead.Length -gt 7) { $currentHead.Substring(0, 7) } else { $currentHead }
+        $shortAfter = if ($afterUpstream.Length -gt 7) { $afterUpstream.Substring(0, 7) } else { $afterUpstream }
+
+        # If fetched upstream is already an ancestor of local HEAD, no update is pending. This is
+        # the important local-ahead case: dirty work must not be offered a pointless Discard path.
+        & git -C $dir.FullName merge-base --is-ancestor $afterUpstream $currentHead 2>$null
+        $ancestorCode = $LASTEXITCODE
+        if ($ancestorCode -gt 1) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'could not compare checkout history with its fetched upstream' }
+            continue
+        }
+        if ($ancestorCode -eq 0) {
+            $detail = $shortCurrent
+            if ($currentHead -ne $afterUpstream) { $detail += ' (local commits kept; tracked upstream already contained)' }
+            if ($changes.Count -gt 0) { $detail += ' (local changes kept)' }
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'current'; Detail = $detail }
+            continue
+        }
+
+        if ($changes.Count -eq 0) {
+            # Try the ordinary non-destructive path first. A checkout merely behind the tracked
+            # upstream lands here and fast-forwards without any special recovery logic.
+            $prev = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            $mergeOutput = (& git -C $dir.FullName merge --ff-only --quiet $afterUpstream 2>&1) -join ' '
+            $mergeCode = $LASTEXITCODE
+            $ErrorActionPreference = $prev
+
+            if ($mergeCode -eq 0) {
+                $mergeHead = ((& git -C $dir.FullName rev-parse HEAD 2>$null) -join '').Trim()
+                if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($mergeHead)) {
+                    $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'fast-forward completed but the resulting HEAD could not be read' }
+                } elseif ($mergeHead -eq $afterUpstream) {
+                    $results += [pscustomobject]@{ Name = $dir.Name; Status = 'updated'; Detail = "$shortCurrent -> $shortAfter" }
+                } else {
+                    $shortMergeHead = if ($mergeHead.Length -gt 7) { $mergeHead.Substring(0, 7) } else { $mergeHead }
+                    $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = "fast-forward ended at unexpected HEAD $shortMergeHead" }
+                }
+                continue
+            }
+
+            # A remote rewrite is the one case where automatic reset is allowed. Revalidate the
+            # complete proof after the failed merge and immediately before reset so work created
+            # during fetch/merge cannot be destroyed by a stale clean snapshot.
+            if ($before -eq $beforeUpstream -and $changesBeforeFetch.Count -eq 0 -and $afterUpstream -ne $beforeUpstream) {
+                $preResetHead = ((& git -C $dir.FullName rev-parse HEAD 2>$null) -join '').Trim()
+                $headOk = $LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($preResetHead)
+                $preResetChanges = @(& git -C $dir.FullName status --short --untracked-files=all 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                $statusOk = $LASTEXITCODE -eq 0
+                $preResetUpstream = ((& git -C $dir.FullName rev-parse '@{u}' 2>$null) -join '').Trim()
+                $upstreamOk = $LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($preResetUpstream)
+
+                if ($headOk -and $statusOk -and $upstreamOk -and
+                    $preResetHead -eq $before -and $preResetChanges.Count -eq 0 -and $preResetUpstream -eq $afterUpstream) {
+                    $prev = $ErrorActionPreference
+                    $ErrorActionPreference = 'Continue'
+                    $resetOutput = (& git -C $dir.FullName reset --hard --quiet $afterUpstream 2>&1) -join ' '
+                    $resetCode = $LASTEXITCODE
+                    $ErrorActionPreference = $prev
+                    $resetHead = ((& git -C $dir.FullName rev-parse HEAD 2>$null) -join '').Trim()
+
+                    if ($resetCode -eq 0 -and $resetHead -eq $afterUpstream) {
+                        $results += [pscustomobject]@{
+                            Name = $dir.Name
+                            Status = 'updated'
+                            Detail = "$shortCurrent -> $shortAfter (upstream history was rewritten; clean checkout recovered)"
+                        }
+                    } else {
+                        $detail = $resetOutput.Trim()
+                        if ([string]::IsNullOrWhiteSpace($detail)) { $detail = 'could not reset clean checkout to rewritten upstream' }
+                        $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = $detail }
+                    }
+                    continue
+                }
+            }
+        }
+
+        # The checkout cannot be updated non-destructively. Refresh once more after the merge
+        # attempt/rewrite proof so the summary and any decision describe the state that exists now.
+        $currentHead = ((& git -C $dir.FullName rev-parse HEAD 2>$null) -join '').Trim()
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($currentHead)) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'could not read checkout HEAD before local-work decision' }
+            continue
+        }
+        $changes = @(& git -C $dir.FullName status --short --untracked-files=all 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($LASTEXITCODE -ne 0) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'could not inspect local changes before local-work decision' }
+            continue
+        }
+
+        # A concurrent/manual update may have made the checkout current while we were trying the
+        # safe paths above. Never prompt if the fetched upstream is already contained now.
+        & git -C $dir.FullName merge-base --is-ancestor $afterUpstream $currentHead 2>$null
+        $ancestorCode = $LASTEXITCODE
+        if ($ancestorCode -gt 1) {
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = 'could not compare checkout history before local-work decision' }
+            continue
+        }
+        if ($ancestorCode -eq 0) {
+            $shortCurrent = if ($currentHead.Length -gt 7) { $currentHead.Substring(0, 7) } else { $currentHead }
+            $detail = $shortCurrent
+            if ($currentHead -ne $afterUpstream) { $detail += ' (local commits kept; tracked upstream already contained)' }
+            if ($changes.Count -gt 0) { $detail += ' (local changes kept)' }
+            $results += [pscustomobject]@{ Name = $dir.Name; Status = 'current'; Detail = $detail }
+            continue
+        }
+
+        # Summarize local history against the pre-fetch upstream so the remote rewrite itself is
+        # never counted as a pile of local commits.
+        $localCommitCount = 0
+        $countText = ((& git -C $dir.FullName rev-list --count "$beforeUpstream..$currentHead" 2>$null) -join '').Trim()
+        if ($LASTEXITCODE -eq 0) {
+            $parsedCount = 0
+            if ([int]::TryParse($countText, [ref]$parsedCount)) { $localCommitCount = $parsedCount }
+        }
+
+        $summaryParts = @()
+        if ($changes.Count -gt 0) {
+            $shown = @($changes | Select-Object -First 5 | ForEach-Object { ([string]$_).Trim() })
+            $extra = if ($changes.Count -gt $shown.Count) { ", +$($changes.Count - $shown.Count) more" } else { '' }
+            $summaryParts += "changes: $($shown -join ', ')$extra"
+        }
+        if ($localCommitCount -gt 0) { $summaryParts += "$localCommitCount local commit(s)" }
+        if ($summaryParts.Count -eq 0) { $summaryParts += 'history differs from the tracked upstream' }
+        $summary = $summaryParts -join '; '
+
+        $decisionFingerprint = Get-GitCheckoutFingerprint -Path $dir.FullName
+        if ([string]::IsNullOrWhiteSpace($decisionFingerprint)) {
+            $results += [pscustomobject]@{
+                Name = $dir.Name
+                Status = 'failed'
+                Detail = 'local work kept; could not fingerprint the checkout safely before a destructive decision'
+            }
+            continue
+        }
+
+        $context = [pscustomobject]@{
+            Name = $dir.Name
+            Path = $dir.FullName
+            Summary = $summary
+            Changes = [string[]]$changes
+            LocalCommitCount = $localCommitCount
+            HeadBefore = $currentHead
+            UpstreamBefore = $beforeUpstream
+            UpstreamAfter = $afterUpstream
+            UpstreamRef = $upstreamRef
+        }
+
+        $decision = 'keep'
+        if ($DecisionProvider) {
+            try {
+                $provided = [string](& $DecisionProvider $context)
+                if (-not [string]::IsNullOrWhiteSpace($provided)) { $decision = $provided.Trim().ToLowerInvariant() }
+            } catch {
+                $decision = 'keep'
+            }
+        }
+
+        if ($decision -in @('discard', 'd', 'reset')) {
+            # Consent applies only to the exact content snapshot that existed when the caller was
+            # asked. Status letters are insufficient: M stays M when the same file is edited again.
+            $decisionHead = ((& git -C $dir.FullName rev-parse HEAD 2>$null) -join '').Trim()
+            $decisionHeadOk = $LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($decisionHead)
+            $decisionUpstream = ((& git -C $dir.FullName rev-parse '@{u}' 2>$null) -join '').Trim()
+            $decisionUpstreamOk = $LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($decisionUpstream)
+            $decisionFingerprintNow = Get-GitCheckoutFingerprint -Path $dir.FullName
+            $decisionFingerprintOk = -not [string]::IsNullOrWhiteSpace($decisionFingerprintNow)
+
+            if (-not ($decisionHeadOk -and $decisionUpstreamOk -and $decisionFingerprintOk) -or
+                $decisionHead -ne $context.HeadBefore -or $decisionUpstream -ne $context.UpstreamAfter -or
+                $decisionFingerprintNow -cne $decisionFingerprint) {
+                $results += [pscustomobject]@{
+                    Name = $dir.Name
+                    Status = 'failed'
+                    Detail = 'local work kept; checkout changed while the discard decision was pending, so nothing was reset'
+                }
+                continue
+            }
+
+            $prev = $ErrorActionPreference
+            $ErrorActionPreference = 'Continue'
+            $resetOutput = (& git -C $dir.FullName reset --hard --quiet $afterUpstream 2>&1) -join ' '
+            $resetCode = $LASTEXITCODE
+            $cleanOutput = ''
+            $cleanCode = 1
+            if ($resetCode -eq 0) {
+                $cleanOutput = (& git -C $dir.FullName clean -fd --quiet 2>&1) -join ' '
+                $cleanCode = $LASTEXITCODE
+            }
+            $ErrorActionPreference = $prev
+
+            $resetHead = ((& git -C $dir.FullName rev-parse HEAD 2>$null) -join '').Trim()
+            $remaining = @(& git -C $dir.FullName status --short --untracked-files=all 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+            if ($resetCode -eq 0 -and $cleanCode -eq 0 -and $resetHead -eq $afterUpstream -and $remaining.Count -eq 0) {
+                $shortCurrent = if ($currentHead.Length -gt 7) { $currentHead.Substring(0, 7) } else { $currentHead }
+                $results += [pscustomobject]@{
+                    Name = $dir.Name
+                    Status = 'updated'
+                    Detail = "$shortCurrent -> $shortAfter (local work discarded by request)"
+                }
+            } else {
+                $detail = (@($resetOutput.Trim(), $cleanOutput.Trim()) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join ' '
+                if ([string]::IsNullOrWhiteSpace($detail)) { $detail = 'discard was requested but the checkout could not be made clean at the tracked upstream' }
+                $results += [pscustomobject]@{ Name = $dir.Name; Status = 'failed'; Detail = $detail }
+            }
+            continue
+        }
+
+        $results += [pscustomobject]@{
+            Name = $dir.Name
+            Status = 'failed'
+            Detail = "local work kept; update skipped ($summary)"
         }
     }
 

--- a/tools/orion-devbuild-installer/update.ps1
+++ b/tools/orion-devbuild-installer/update.ps1
@@ -94,7 +94,21 @@ if (-not $pluginReady) {
     }
 }
 
-$companions = @(Update-CompanionUserplugins -InstallDir $InstallDir)
+$companionDecisionProvider = {
+    param($context)
+
+    Warn "  $($context.Name): upstream changed, but this checkout has local work."
+    Write-Host "    $($context.Summary)"
+    try {
+        $answer = [string](Read-Host '    [K]eep local work and skip this plugin update / [D]iscard it and update (default K)')
+        if (-not [string]::IsNullOrWhiteSpace($answer) -and $answer.Trim().ToLowerInvariant() -in @('d', 'discard')) {
+            return 'discard'
+        }
+    } catch { }
+    return 'keep'
+}
+
+$companions = @(Update-CompanionUserplugins -InstallDir $InstallDir -DecisionProvider $companionDecisionProvider)
 if ($companions.Count -gt 0) {
     Info 'Updating other userplugins in this checkout...'
     foreach ($c in $companions) {

--- a/tools/tests/companion-update-fingerprint-regression.ps1
+++ b/tools/tests/companion-update-fingerprint-regression.ps1
@@ -1,0 +1,95 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$Helper = Join-Path $RepoRoot 'tools\orion-devbuild-installer\installer-common.ps1'
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw $Message }
+}
+function Assert-Equal($Actual, $Expected, [string]$Message) {
+    if ($Actual -ne $Expected) { throw "$Message`nExpected: $Expected`nActual:   $Actual" }
+}
+
+Assert-True (Test-Path -LiteralPath $Helper -PathType Leaf) 'installer-common.ps1 is required.'
+. $Helper
+
+$gitCommand = Get-Command git -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $gitCommand) {
+    Write-Host '  SKIP: companion fingerprint regression needs git on PATH.' -ForegroundColor Yellow
+    exit 0
+}
+$realGit = $gitCommand.Source
+
+function Invoke-TestGit {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+    & $realGit @Arguments 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "git failed: git $($Arguments -join ' ')" }
+}
+
+function Read-GitValue {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+    $value = ((& $realGit -C $Path @Arguments 2>$null) -join '').Trim()
+    if ($LASTEXITCODE -ne 0) { throw "git failed in ${Path}: git $($Arguments -join ' ')" }
+    return $value
+}
+
+$temp = Join-Path ([IO.Path]::GetTempPath()) ("orion-companion-fingerprint-test-" + [guid]::NewGuid().ToString('N'))
+try {
+    $upstream = Join-Path $temp 'upstream'
+    New-Item -ItemType Directory -Force -Path $upstream | Out-Null
+    Invoke-TestGit @('-C', $upstream, 'init', '--quiet', '--initial-branch=main')
+    Invoke-TestGit @('-C', $upstream, 'config', 'user.email', 'test@example.invalid')
+    Invoke-TestGit @('-C', $upstream, 'config', 'user.name', 'installer regression')
+
+    Set-Content -LiteralPath (Join-Path $upstream 'index.tsx') -Value 'first' -Encoding ASCII
+    Invoke-TestGit @('-C', $upstream, 'add', '-A')
+    Invoke-TestGit @('-C', $upstream, 'commit', '--quiet', '-m', 'first')
+    $first = Read-GitValue -Path $upstream -Arguments @('rev-parse', 'HEAD')
+
+    Set-Content -LiteralPath (Join-Path $upstream 'index.tsx') -Value 'old second' -Encoding ASCII
+    Invoke-TestGit @('-C', $upstream, 'add', '-A')
+    Invoke-TestGit @('-C', $upstream, 'commit', '--quiet', '-m', 'old second')
+
+    $install = Join-Path $temp 'install'
+    $userplugins = Join-Path $install 'src\userplugins'
+    New-Item -ItemType Directory -Force -Path $userplugins | Out-Null
+    $checkout = Join-Path $userplugins 'SameFileDecisionRace'
+    Invoke-TestGit @('clone', '--quiet', $upstream, $checkout)
+
+    Set-Content -LiteralPath (Join-Path $checkout 'index.tsx') -Value 'dirty before decision' -Encoding ASCII
+    $headBefore = Read-GitValue -Path $checkout -Arguments @('rev-parse', 'HEAD')
+
+    # Rewrite upstream so the dirty checkout needs a Keep/Discard decision.
+    Invoke-TestGit @('-C', $upstream, 'reset', '--hard', '--quiet', $first)
+    Set-Content -LiteralPath (Join-Path $upstream 'index.tsx') -Value 'rewritten second' -Encoding ASCII
+    Invoke-TestGit @('-C', $upstream, 'add', '-A')
+    Invoke-TestGit @('-C', $upstream, 'commit', '--quiet', '-m', 'rewritten second')
+
+    $decisionCalls = 0
+    $results = @(Update-CompanionUserplugins -InstallDir $install -DecisionProvider {
+        param($context)
+        $script:decisionCalls++
+        if ($context.Name -eq 'SameFileDecisionRace') {
+            # Keep the same `M index.tsx` status line but change the bytes after consent context
+            # was captured. A status-only revalidation would miss this and reset the new edit.
+            Set-Content -LiteralPath (Join-Path $context.Path 'index.tsx') -Value 'mutated during decision' -Encoding ASCII
+            return 'discard'
+        }
+        return 'keep'
+    })
+
+    Assert-Equal $results.Count 1 'The fingerprint fixture should produce exactly one updater result.'
+    Assert-Equal $decisionCalls 1 'The pending rewrite should ask exactly one local-work decision.'
+    Assert-Equal $results[0].Status 'failed' 'Changing the same dirty file during Discard must invalidate the destructive decision.'
+    Assert-True ($results[0].Detail -match 'changed while the discard decision was pending') 'The updater should explain why Discard was cancelled.'
+    Assert-Equal (Read-GitValue -Path $checkout -Arguments @('rev-parse', 'HEAD')) $headBefore 'Cancelled Discard must preserve the original HEAD.'
+    Assert-Equal (Get-Content -LiteralPath (Join-Path $checkout 'index.tsx') -Raw).Trim() 'mutated during decision' 'Cancelled Discard must preserve the bytes written after the decision context was shown.'
+} finally {
+    Remove-Item -LiteralPath $temp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host 'Companion destructive-decision fingerprint regression passed.' -ForegroundColor Green

--- a/tools/tests/companion-update-regression.ps1
+++ b/tools/tests/companion-update-regression.ps1
@@ -1,0 +1,279 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$Helper = Join-Path $RepoRoot 'tools\orion-devbuild-installer\installer-common.ps1'
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw $Message }
+}
+function Assert-False([bool]$Condition, [string]$Message) {
+    if ($Condition) { throw $Message }
+}
+function Assert-Equal($Actual, $Expected, [string]$Message) {
+    if ($Actual -ne $Expected) { throw "$Message`nExpected: $Expected`nActual:   $Actual" }
+}
+
+Assert-True (Test-Path -LiteralPath $Helper -PathType Leaf) 'installer-common.ps1 is required.'
+. $Helper
+
+$gitCommand = Get-Command git -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $gitCommand) {
+    Write-Host '  SKIP: companion rewrite regression needs git on PATH.' -ForegroundColor Yellow
+    exit 0
+}
+$realGit = $gitCommand.Source
+
+function Invoke-TestGit {
+    param([Parameter(Mandatory)][string[]]$Arguments)
+    & $realGit @Arguments 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "git failed: git $($Arguments -join ' ')" }
+}
+
+function Read-GitValue {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+    $value = ((& $realGit -C $Path @Arguments 2>$null) -join '').Trim()
+    if ($LASTEXITCODE -ne 0) { throw "git failed in ${Path}: git $($Arguments -join ' ')" }
+    return $value
+}
+
+$temp = Join-Path ([IO.Path]::GetTempPath()) ("orion-companion-rewrite-test-" + [guid]::NewGuid().ToString('N'))
+try {
+    $upstream = Join-Path $temp 'upstream'
+    New-Item -ItemType Directory -Force -Path $upstream | Out-Null
+    Invoke-TestGit @('-C', $upstream, 'init', '--quiet', '--initial-branch=main')
+    Invoke-TestGit @('-C', $upstream, 'config', 'user.email', 'test@example.invalid')
+    Invoke-TestGit @('-C', $upstream, 'config', 'user.name', 'installer regression')
+
+    Set-Content -LiteralPath (Join-Path $upstream 'index.tsx') -Value 'first' -Encoding ASCII
+    Invoke-TestGit @('-C', $upstream, 'add', '-A')
+    Invoke-TestGit @('-C', $upstream, 'commit', '--quiet', '-m', 'first')
+    $first = Read-GitValue -Path $upstream -Arguments @('rev-parse', 'HEAD')
+
+    Set-Content -LiteralPath (Join-Path $upstream 'index.tsx') -Value 'old second' -Encoding ASCII
+    Invoke-TestGit @('-C', $upstream, 'add', '-A')
+    Invoke-TestGit @('-C', $upstream, 'commit', '--quiet', '-m', 'old second')
+    $oldRemoteHead = Read-GitValue -Path $upstream -Arguments @('rev-parse', 'HEAD')
+
+    # A local-ahead checkout already contains the tracked upstream, so there is no remote update
+    # to apply. This remains true when the checkout is dirty: UPDATE must not ask a destructive
+    # Keep/Discard question for work that is already current.
+    $aheadInstall = Join-Path $temp 'ahead-install'
+    $aheadUserplugins = Join-Path $aheadInstall 'src\userplugins'
+    New-Item -ItemType Directory -Force -Path $aheadUserplugins | Out-Null
+
+    $ahead = Join-Path $aheadUserplugins 'LocalAheadCurrent'
+    Invoke-TestGit @('clone', '--quiet', $upstream, $ahead)
+    Invoke-TestGit @('-C', $ahead, 'config', 'user.email', 'test@example.invalid')
+    Invoke-TestGit @('-C', $ahead, 'config', 'user.name', 'installer regression')
+    Set-Content -LiteralPath (Join-Path $ahead 'local.txt') -Value 'local ahead' -Encoding ASCII
+    Invoke-TestGit @('-C', $ahead, 'add', '-A')
+    Invoke-TestGit @('-C', $ahead, 'commit', '--quiet', '-m', 'local ahead')
+    $aheadHead = Read-GitValue -Path $ahead -Arguments @('rev-parse', 'HEAD')
+
+    $aheadDirty = Join-Path $aheadUserplugins 'LocalAheadDirtyCurrent'
+    Invoke-TestGit @('clone', '--quiet', $upstream, $aheadDirty)
+    Invoke-TestGit @('-C', $aheadDirty, 'config', 'user.email', 'test@example.invalid')
+    Invoke-TestGit @('-C', $aheadDirty, 'config', 'user.name', 'installer regression')
+    Set-Content -LiteralPath (Join-Path $aheadDirty 'local-commit.txt') -Value 'local ahead' -Encoding ASCII
+    Invoke-TestGit @('-C', $aheadDirty, 'add', '-A')
+    Invoke-TestGit @('-C', $aheadDirty, 'commit', '--quiet', '-m', 'local ahead')
+    Set-Content -LiteralPath (Join-Path $aheadDirty 'work-in-progress.txt') -Value 'do not discard' -Encoding ASCII
+    $aheadDirtyHead = Read-GitValue -Path $aheadDirty -Arguments @('rev-parse', 'HEAD')
+
+    $aheadDecisionCalls = 0
+    $aheadResults = @(Update-CompanionUserplugins -InstallDir $aheadInstall -DecisionProvider {
+        param($context)
+        $script:aheadDecisionCalls++
+        return 'discard'
+    })
+    $aheadByName = @{}
+    foreach ($row in $aheadResults) { $aheadByName[$row.Name] = $row }
+
+    Assert-Equal $aheadByName['LocalAheadCurrent'].Status 'current' 'A clean local-ahead checkout with unchanged upstream must be current, not updated.'
+    Assert-Equal (Read-GitValue -Path $ahead -Arguments @('rev-parse', 'HEAD')) $aheadHead 'Checking a clean local-ahead checkout must not move its HEAD.'
+    Assert-True ($aheadByName['LocalAheadCurrent'].Detail -match 'local commits kept') 'The current result should explain that local commits were kept.'
+
+    Assert-Equal $aheadByName['LocalAheadDirtyCurrent'].Status 'current' 'A dirty local-ahead checkout that already contains upstream must also be current.'
+    Assert-Equal (Read-GitValue -Path $aheadDirty -Arguments @('rev-parse', 'HEAD')) $aheadDirtyHead 'A dirty local-ahead checkout must keep its local commit.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $aheadDirty 'work-in-progress.txt') -PathType Leaf) 'A dirty local-ahead checkout must keep its working file.'
+    Assert-Equal $aheadDecisionCalls 0 'Already-current local-ahead checkouts must never be offered a destructive Discard decision.'
+
+    $userplugins = Join-Path $temp 'install\src\userplugins'
+    New-Item -ItemType Directory -Force -Path $userplugins | Out-Null
+    $names = @(
+        'RewriteClean', 'RewriteDirty', 'RewriteStaged', 'RewriteUntracked', 'RewriteLocalCommit',
+        'RewriteDiscard', 'RewriteDecisionRace', 'orionQuests'
+    )
+    foreach ($name in $names) {
+        Invoke-TestGit @('clone', '--quiet', $upstream, (Join-Path $userplugins $name))
+    }
+
+    # Separate fixtures are cloned before the remote rewrite so their remembered origin/main is
+    # exactly the old SHA an installed companion would have seen.
+    $defaultKeepInstall = Join-Path $temp 'default-keep-install'
+    $defaultKeepUserplugins = Join-Path $defaultKeepInstall 'src\userplugins'
+    New-Item -ItemType Directory -Force -Path $defaultKeepUserplugins | Out-Null
+    $defaultKeep = Join-Path $defaultKeepUserplugins 'RewriteDefaultKeep'
+    Invoke-TestGit @('clone', '--quiet', $upstream, $defaultKeep)
+    Set-Content -LiteralPath (Join-Path $defaultKeep 'index.tsx') -Value 'noninteractive local edit' -Encoding ASCII
+    $defaultKeepHead = Read-GitValue -Path $defaultKeep -Arguments @('rev-parse', 'HEAD')
+
+    $raceInstall = Join-Path $temp 'race-install'
+    $raceUserplugins = Join-Path $raceInstall 'src\userplugins'
+    New-Item -ItemType Directory -Force -Path $raceUserplugins | Out-Null
+    $race = Join-Path $raceUserplugins 'RewriteRace'
+    Invoke-TestGit @('clone', '--quiet', $upstream, $race)
+    $raceHead = Read-GitValue -Path $race -Arguments @('rev-parse', 'HEAD')
+
+    $dirty = Join-Path $userplugins 'RewriteDirty'
+    Set-Content -LiteralPath (Join-Path $dirty 'index.tsx') -Value 'local dirty edit' -Encoding ASCII
+
+    $staged = Join-Path $userplugins 'RewriteStaged'
+    Set-Content -LiteralPath (Join-Path $staged 'staged.txt') -Value 'staged work' -Encoding ASCII
+    Invoke-TestGit @('-C', $staged, 'add', 'staged.txt')
+
+    $untracked = Join-Path $userplugins 'RewriteUntracked'
+    Set-Content -LiteralPath (Join-Path $untracked 'untracked.txt') -Value 'untracked work' -Encoding ASCII
+
+    $localCommit = Join-Path $userplugins 'RewriteLocalCommit'
+    Invoke-TestGit @('-C', $localCommit, 'config', 'user.email', 'test@example.invalid')
+    Invoke-TestGit @('-C', $localCommit, 'config', 'user.name', 'installer regression')
+    Set-Content -LiteralPath (Join-Path $localCommit 'local.txt') -Value 'local commit' -Encoding ASCII
+    Invoke-TestGit @('-C', $localCommit, 'add', '-A')
+    Invoke-TestGit @('-C', $localCommit, 'commit', '--quiet', '-m', 'local only')
+    $localCommitHead = Read-GitValue -Path $localCommit -Arguments @('rev-parse', 'HEAD')
+
+    $discard = Join-Path $userplugins 'RewriteDiscard'
+    Set-Content -LiteralPath (Join-Path $discard 'index.tsx') -Value 'discard me' -Encoding ASCII
+    Set-Content -LiteralPath (Join-Path $discard 'remove-me.txt') -Value 'untracked discard' -Encoding ASCII
+    Add-Content -LiteralPath (Join-Path $discard '.git\info\exclude') -Value 'ignored-local.txt'
+    Set-Content -LiteralPath (Join-Path $discard 'ignored-local.txt') -Value 'keep ignored local data' -Encoding ASCII
+
+    $decisionRace = Join-Path $userplugins 'RewriteDecisionRace'
+    Set-Content -LiteralPath (Join-Path $decisionRace 'index.tsx') -Value 'original local edit' -Encoding ASCII
+
+    # Rewrite upstream from the first commit so the old second commit is no longer an ancestor.
+    # Every untouched clone still has HEAD == its pre-fetch origin/main at oldRemoteHead.
+    Invoke-TestGit @('-C', $upstream, 'reset', '--hard', '--quiet', $first)
+    Set-Content -LiteralPath (Join-Path $upstream 'index.tsx') -Value 'rewritten second' -Encoding ASCII
+    Invoke-TestGit @('-C', $upstream, 'add', '-A')
+    Invoke-TestGit @('-C', $upstream, 'commit', '--quiet', '-m', 'rewritten second')
+    $newRemoteHead = Read-GitValue -Path $upstream -Arguments @('rev-parse', 'HEAD')
+    Assert-False ($newRemoteHead -eq $oldRemoteHead) 'The fixture must actually rewrite upstream history.'
+
+    $decisionCalls = New-Object System.Collections.Generic.List[string]
+    $decisionProvider = {
+        param($context)
+        [void]$decisionCalls.Add([string]$context.Name)
+        if ($context.Name -eq 'RewriteDiscard') { return 'discard' }
+        if ($context.Name -eq 'RewriteDecisionRace') {
+            # Simulate the checkout changing after the summary was shown but before the user
+            # answered. Explicit consent for the old snapshot must not discard this new work.
+            Set-Content -LiteralPath (Join-Path $context.Path 'arrived-during-decision.txt') -Value 'new work' -Encoding ASCII
+            return 'discard'
+        }
+        return 'keep'
+    }
+
+    $results = @(Update-CompanionUserplugins -InstallDir (Join-Path $temp 'install') -DecisionProvider $decisionProvider)
+    $byName = @{}
+    foreach ($row in $results) { $byName[$row.Name] = $row }
+
+    Assert-False ($byName.ContainsKey('orionQuests')) 'orionQuests must stay outside the companion updater.'
+
+    $clean = Join-Path $userplugins 'RewriteClean'
+    Assert-Equal $byName['RewriteClean'].Status 'updated' 'A clean untouched checkout must recover automatically from an upstream rewrite.'
+    Assert-Equal (Read-GitValue -Path $clean -Arguments @('rev-parse', 'HEAD')) $newRemoteHead 'Clean rewrite recovery must land exactly on the fetched upstream.'
+    Assert-Equal (Get-Content -LiteralPath (Join-Path $clean 'index.tsx') -Raw).Trim() 'rewritten second' 'Clean rewrite recovery must install the rewritten content.'
+    Assert-True ($byName['RewriteClean'].Detail -match 'history was rewritten') 'Clean rewrite recovery should explain why a reset was safe.'
+    Assert-False ($decisionCalls.Contains('RewriteClean')) 'An untouched checkout must never prompt for a rewrite it can prove is upstream-only.'
+
+    Assert-Equal $byName['RewriteDirty'].Status 'failed' 'An unstaged edit must be kept unless the user explicitly discards it.'
+    Assert-Equal (Read-GitValue -Path $dirty -Arguments @('rev-parse', 'HEAD')) $oldRemoteHead 'Keeping an unstaged edit must not move HEAD.'
+    Assert-Equal (Get-Content -LiteralPath (Join-Path $dirty 'index.tsx') -Raw).Trim() 'local dirty edit' 'Keeping an unstaged edit must preserve its contents.'
+    Assert-True ($decisionCalls.Contains('RewriteDirty')) 'An unstaged edit must require a user decision when an update is actually pending.'
+
+    Assert-Equal $byName['RewriteStaged'].Status 'failed' 'A staged edit must be protected by default.'
+    Assert-Equal (Read-GitValue -Path $staged -Arguments @('rev-parse', 'HEAD')) $oldRemoteHead 'Keeping staged work must not move HEAD.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $staged 'staged.txt') -PathType Leaf) 'Keeping staged work must preserve the file.'
+    Assert-True ($decisionCalls.Contains('RewriteStaged')) 'Staged work must require a user decision when an update is actually pending.'
+
+    Assert-Equal $byName['RewriteUntracked'].Status 'failed' 'An untracked file must be protected by default.'
+    Assert-Equal (Read-GitValue -Path $untracked -Arguments @('rev-parse', 'HEAD')) $oldRemoteHead 'Keeping untracked work must not move HEAD.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $untracked 'untracked.txt') -PathType Leaf) 'Keeping untracked work must preserve the file.'
+    Assert-True ($decisionCalls.Contains('RewriteUntracked')) 'Untracked work must require a user decision when an update is actually pending.'
+
+    Assert-Equal $byName['RewriteLocalCommit'].Status 'failed' 'A clean local-only commit must never be mistaken for an untouched checkout.'
+    Assert-Equal (Read-GitValue -Path $localCommit -Arguments @('rev-parse', 'HEAD')) $localCommitHead 'Keeping a local commit must preserve its HEAD.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $localCommit 'local.txt') -PathType Leaf) 'Keeping a local commit must preserve its content.'
+    Assert-True ($byName['RewriteLocalCommit'].Detail -match '1 local commit') 'The updater should summarize local history without counting the remote rewrite itself.'
+    Assert-True ($decisionCalls.Contains('RewriteLocalCommit')) 'A local-only commit must require a user decision when an update is pending.'
+
+    Assert-Equal $byName['RewriteDiscard'].Status 'updated' 'Explicit discard must allow a locally modified checkout to update.'
+    Assert-Equal (Read-GitValue -Path $discard -Arguments @('rev-parse', 'HEAD')) $newRemoteHead 'Explicit discard must land exactly on the fetched upstream.'
+    Assert-Equal (Get-Content -LiteralPath (Join-Path $discard 'index.tsx') -Raw).Trim() 'rewritten second' 'Explicit discard must restore tracked files from upstream.'
+    Assert-False (Test-Path -LiteralPath (Join-Path $discard 'remove-me.txt')) 'Explicit discard must remove non-ignored untracked files.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $discard 'ignored-local.txt') -PathType Leaf) 'Explicit discard must preserve ignored local files.'
+    $discardStatus = @(& $realGit -C $discard status --short --untracked-files=all 2>$null)
+    Assert-Equal $discardStatus.Count 0 'Explicit discard must leave a clean checkout apart from ignored files.'
+    Assert-True ($decisionCalls.Contains('RewriteDiscard')) 'A destructive discard must only happen after an explicit decision.'
+
+    Assert-Equal $byName['RewriteDecisionRace'].Status 'failed' 'A checkout that changes while Discard is being decided must be kept instead of reset.'
+    Assert-Equal (Read-GitValue -Path $decisionRace -Arguments @('rev-parse', 'HEAD')) $oldRemoteHead 'Decision-time mutation must abort the reset and preserve HEAD.'
+    Assert-Equal (Get-Content -LiteralPath (Join-Path $decisionRace 'index.tsx') -Raw).Trim() 'original local edit' 'Decision-time mutation must preserve the original tracked edit.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $decisionRace 'arrived-during-decision.txt') -PathType Leaf) 'Decision-time mutation must preserve work created after the summary.'
+    Assert-True ($byName['RewriteDecisionRace'].Detail -match 'changed while the discard decision was pending') 'The updater should explain why the destructive decision was cancelled.'
+
+    # Non-interactive callers deliberately have no Read-Host fallback. With local work present,
+    # no DecisionProvider means Keep and must never reset either tracked content or HEAD.
+    $defaultKeepResults = @(Update-CompanionUserplugins -InstallDir $defaultKeepInstall)
+    Assert-Equal $defaultKeepResults.Count 1 'The non-interactive keep fixture should produce one result.'
+    Assert-Equal $defaultKeepResults[0].Status 'failed' 'Without a DecisionProvider, local work must be kept and the update skipped.'
+    Assert-True ($defaultKeepResults[0].Detail -match 'local work kept') 'The default Keep result should explain why the update was skipped.'
+    Assert-Equal (Read-GitValue -Path $defaultKeep -Arguments @('rev-parse', 'HEAD')) $defaultKeepHead 'Default Keep must not move HEAD.'
+    Assert-Equal (Get-Content -LiteralPath (Join-Path $defaultKeep 'index.tsx') -Raw).Trim() 'noninteractive local edit' 'Default Keep must preserve local tracked content.'
+
+    # Deterministically inject a new local edit after the non-fast-forward merge fails but before
+    # the auto-rewrite recovery reaches reset --hard. The updater must revalidate its old clean
+    # proof and preserve this edit instead of relying on the pre-fetch snapshot.
+    $global:OrionRegressionRealGit = $realGit
+    $global:OrionRegressionRaceCheckout = $race
+    $global:OrionRegressionRaceInjected = $false
+    function global:git {
+        $captured = @($args)
+        & $global:OrionRegressionRealGit @captured
+        $code = $LASTEXITCODE
+        if (-not $global:OrionRegressionRaceInjected -and $code -ne 0 -and
+            $captured -contains 'merge' -and $captured -contains $global:OrionRegressionRaceCheckout) {
+            Set-Content -LiteralPath (Join-Path $global:OrionRegressionRaceCheckout 'arrived-before-reset.txt') -Value 'new local work' -Encoding ASCII
+            $global:OrionRegressionRaceInjected = $true
+        }
+        $global:LASTEXITCODE = $code
+    }
+    try {
+        $raceResults = @(Update-CompanionUserplugins -InstallDir $raceInstall)
+    } finally {
+        Remove-Item Function:\git -Force -ErrorAction SilentlyContinue
+        Remove-Variable OrionRegressionRealGit -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable OrionRegressionRaceCheckout -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable OrionRegressionRaceInjected -Scope Global -ErrorAction SilentlyContinue
+    }
+    Assert-Equal $raceResults.Count 1 'The reset-race fixture should produce one updater result.'
+    Assert-Equal $raceResults[0].Status 'failed' 'New work appearing before auto-reset must invalidate the automatic recovery proof.'
+    Assert-Equal (Read-GitValue -Path $race -Arguments @('rev-parse', 'HEAD')) $raceHead 'Auto-reset revalidation must preserve the old HEAD when new work appears.'
+    Assert-True (Test-Path -LiteralPath (Join-Path $race 'arrived-before-reset.txt') -PathType Leaf) 'Auto-reset revalidation must preserve work that arrived after merge failed.'
+
+    Assert-Equal @(Update-CompanionUserplugins -InstallDir (Join-Path $temp 'missing')).Count 0 'A missing userplugins directory must still be a no-op.'
+} finally {
+    Remove-Item Function:\git -Force -ErrorAction SilentlyContinue
+    Remove-Variable OrionRegressionRealGit -Scope Global -ErrorAction SilentlyContinue
+    Remove-Variable OrionRegressionRaceCheckout -Scope Global -ErrorAction SilentlyContinue
+    Remove-Variable OrionRegressionRaceInjected -Scope Global -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $temp -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host 'Companion rewrite regression passed.' -ForegroundColor Green

--- a/traffic.ts
+++ b/traffic.ts
@@ -17,6 +17,8 @@
 
 import { Logger } from "@utils/Logger";
 
+import { companionFailure, COMPANION_EVENT_CODES, emitCompanionEvent } from "./companionEvents";
+
 const logger = new Logger("OrionQuests");
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
@@ -31,6 +33,7 @@ export interface TrafficLogger {
 const RETRYABLE = new Set([429, 500, 502, 503, 504, 408]);
 const CLIENT_ERRORS = new Set([400, 403, 404, 409, 410]);
 const MAX_RETRIES = 3;
+const MAX_ATTEMPTS = MAX_RETRIES + 1;
 
 type RequestPhase = "queued" | "inflight" | "backoff" | "settled";
 
@@ -39,6 +42,7 @@ interface QueuedRequest {
     body: unknown;
     resolve: (value: any) => void;
     reject: (reason: any) => void;
+    /** Retries already scheduled; the actual request attempt is attempts + 1. */
     attempts: number;
     isActive: () => boolean;
     signal?: AbortSignal;
@@ -51,15 +55,18 @@ interface ClassifiedError {
     isRetryable: boolean;
     isClientError: boolean;
     status: number | undefined;
+    upstreamCode: string | number | null;
     message: string;
 }
 
 function classify(error: any): ClassifiedError {
     const status = error?.status ?? error?.statusCode;
+    const rawCode = error?.body?.code ?? error?.code;
     return {
         isRetryable: RETRYABLE.has(status),
         isClientError: CLIENT_ERRORS.has(status),
         status,
+        upstreamCode: typeof rawCode === "string" || typeof rawCode === "number" ? rawCode : null,
         message: error?.message ?? error?.body?.message ?? `HTTP ${status ?? "UNKNOWN"}`,
     };
 }
@@ -68,6 +75,61 @@ function cancelledError(): Error {
     const error = new Error("Task cancelled");
     error.name = "AbortError";
     return error;
+}
+
+function questIdFromUrl(url: string): string | undefined {
+    return url.match(/^\/quests\/(\d+)(?:\/|$)/)?.[1];
+}
+
+function emitNetworkRetry(req: QueuedRequest, err: ClassifiedError): void {
+    const actualAttempt = req.attempts + 1;
+    const statusText = err.status != null ? ` after HTTP ${err.status}` : "";
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.NETWORK_RETRY,
+        category: "network",
+        level: "warning",
+        message: `Quest request attempt ${actualAttempt} failed${statusText}; Orion will retry.`,
+        questId: questIdFromUrl(req.url),
+        failure: companionFailure({
+            terminal: false,
+            retryable: true,
+            attempt: actualAttempt,
+            maxAttempts: MAX_ATTEMPTS,
+            httpStatus: err.status,
+            upstreamCode: err.upstreamCode,
+            reason: err.message,
+        }),
+    });
+}
+
+function emitNetworkFailure(req: QueuedRequest, err: ClassifiedError): void {
+    const actualAttempt = req.attempts + 1;
+    const exhaustedRetry = err.isRetryable && req.attempts >= MAX_RETRIES;
+    const statusText = err.status != null ? ` (HTTP ${err.status})` : "";
+    emitCompanionEvent({
+        code: COMPANION_EVENT_CODES.NETWORK_FAILED,
+        category: "network",
+        level: exhaustedRetry || !err.isClientError ? "error" : "warning",
+        message: exhaustedRetry
+            ? `Quest request failed after ${actualAttempt} attempts${statusText}.`
+            : `Quest request failed${statusText}.`,
+        questId: questIdFromUrl(req.url),
+        failure: companionFailure({
+            // This is terminal for this queued HTTP operation. The owning task may still choose a
+            // fallback (for example ACHIEVEMENT heartbeat -> OAuth bypass), which is represented
+            // separately by the task-level events rather than hidden in this request event.
+            terminal: true,
+            retryable: err.isRetryable,
+            attempt: actualAttempt,
+            // A non-retryable response may terminate a request after earlier retryable failures.
+            // In that case the effective operation budget ended on this actual attempt; never
+            // publish an impossible pair such as attempt=2,maxAttempts=1.
+            maxAttempts: err.isRetryable ? MAX_ATTEMPTS : actualAttempt,
+            httpStatus: err.status,
+            upstreamCode: err.upstreamCode,
+            reason: err.message,
+        }),
+    });
 }
 
 export function isSkippableQuest(error: any): boolean {
@@ -196,6 +258,7 @@ export class Traffic {
                 const err = classify(e);
 
                 if (err.isRetryable && req.attempts < MAX_RETRIES) {
+                    emitNetworkRetry(req, err);
                     req.attempts++;
                     const delay = (e.body?.retry_after ?? Math.pow(2, req.attempts)) * 1000;
                     const isGlobal = e.body?.global === true;
@@ -223,9 +286,11 @@ export class Traffic {
                     }
                 } else if (err.isClientError) {
                     this.log.debug(`[Network] HTTP ${err.status}: ${req.url}`);
+                    emitNetworkFailure(req, err);
                     this.settleReject(req, e);
                 } else {
                     this.log.error(`[Network] Request to ${req.url} failed: ${err.message}`);
+                    emitNetworkFailure(req, err);
                     this.settleReject(req, e);
                 }
             }


### PR DESCRIPTION
## Summary

Adds a structured, read-only companion event API for the Vencord plugin, together with normalized failure metadata, while keeping Orion as the source of truth for engine/task state.

This PR also hardens the companion-userplugin updater so clean checkouts can recover safely from upstream history rewrites without risking local work.

This implements the first part of #80. Scheduler metadata remains intentionally out of scope for a separate follow-up PR.

## Why

QuestUI currently has to infer some Orion runtime semantics from human-readable console output.

That is fragile for cases where the wording alone cannot reliably distinguish:

* a retryable request failure;
* exhausted retries;
* heartbeat failure vs. heartbeat give-up;
* a fallback that is still in progress;
* an action-required condition;
* a terminal task failure.

Orion already knows those facts at the point where they happen, so companions should be able to observe them directly instead of reverse-engineering them from log text.

While preparing this work, the companion updater also needed a safe recovery path for checkouts whose upstream repository rewrote history. The old `--ff-only` behavior correctly refused to destroy local work, but also left a completely untouched checkout stuck after an upstream force-push.

Addresses the structured-events/failure-metadata portion of #80.

## Changes

### Companion updater recovery

* Preserve the normal `--ff-only` path for ordinary updates.
* Detect the narrow case where an untouched checkout only diverged because its tracked upstream rewrote history.
* Automatically recover only when Orion can prove:

  * the checkout was clean;
  * `HEAD` matched the pre-fetch upstream;
  * the tracked upstream actually moved;
  * the same conditions still hold immediately before the destructive reset.
* Treat local-ahead checkouts that already contain the fetched upstream as current, including when their worktree is dirty.
* Preserve unstaged changes, staged changes, untracked files and local commits by default.
* Default to **Keep** when no decision provider is available.
* Allow an explicit **Discard** decision to reset tracked work and remove non-ignored untracked files.
* Revalidate `HEAD`, upstream and a content-aware checkout fingerprint before honoring Discard so consent for one snapshot cannot destroy work that changed while the prompt was open.
* Keep ignored files untouched.
* Keep `orionQuests` itself outside the companion-updater path.
* Add PowerShell regression coverage for rewrite recovery, local work preservation, local-ahead behavior, discard races and content changes during a pending destructive decision.

### Structured companion events

Add an additive:

```ts
subscribeEvents(listener): () => void
```

companion capability.

The existing control surface remains unchanged and continues to own current engine/task control state.

Events expose structured fields such as:

* event code/category/level;
* quest id/name;
* task type;
* semantic reason;
* normalized failure metadata.

Failure metadata includes:

```ts
{
    terminal,
    retryable,
    attempt,
    maxAttempts,
    httpStatus,
    upstreamCode,
    reason
}
```

### Event semantics

Add stable lifecycle/failure events for:

* engine start / running failure / stop;
* blocked quests;
* enrollment;
* task start/completion/failure;
* reward claim results;
* network retry/exhaustion;
* heartbeat failure/give-up;
* achievement fallback;
* Discord Says bypass start/success/failure.

Diagnostic startup/cycle/system/patcher events are explicitly marked provisional.

Every published event code must declare whether its contract is `stable` or `provisional`.

### Failure handling

* Keep request-level failure separate from task-level failure.
* Preserve the distinction between:

  * retry;
  * exhausted request;
  * fallback;
  * recovered fallback;
  * terminal task failure.
* Use actual 1-based request attempts.
* `MAX_RETRIES = 3` therefore means a maximum of 4 request attempts.
* A first-attempt non-retryable response reports `1/1`.
* A request that retries once and then receives a non-retryable response reports `2/2`.
* Do not publish impossible `maxAttempts < attempt` pairs.
* Extract heartbeat HTTP status/upstream code before human-readable error formatting.

### Lifecycle safety

* Event delivery is observational rather than a synchronous control hook.
* Listener membership is snapshotted at emission time and delivery occurs on the next microtask in FIFO order.
* Listener exceptions are isolated from Orion and from other listeners.
* Cancellation/generation checks remain authoritative for queued, retrying and in-flight work.
* A request already on the wire is still allowed to settle, but a cancelled generation cannot publish later progress/failure work.
* Guard synchronous dashboard re-entry so Stop cannot destructively clean engine state in the middle of a transition that is still publishing its result.

### Privacy

Structured events do not expose request bodies, authorization headers, cookies, OAuth codes, proxy tickets or Discord Says credentials.

Credential-shaped values are also sanitized at the producer boundary, including ordinary key/value text, query strings and stringified JSON error objects.

### Companion API compatibility

* `subscribeEvents` is additive.
* Existing `getEngineRunning`, `subscribeEngineRunning`, control snapshot/subscription and Start/Stop/Pause/Resume methods are unchanged.
* Older compatible Orion builds remain usable by companions through feature detection/fallback.
* Orion remains the source of truth; this API does not create or require a mirrored engine state.

## Out of scope

This PR deliberately does **not** include:

* scheduler metadata;
* queue position;
* scheduler mirroring in companion plugins;
* changes to farming/scheduling behavior;
* the OAuth grant-cleanup race tracked separately in #81.

Scheduler metadata will be handled in a later PR.

## Testing

### Vencord plugin

Final branch HEAD passed the full Vencord plugin workflow:

* [x] Node test suite
* [x] TypeScript checks
* [x] Lint
* [x] Vencord build
* [x] Renderer/native bundle assertions
* [x] `subscribeEvents` bundle assertion

Additional regression coverage includes:

* event immutability and listener ordering;
* asynchronous observer delivery;
* listener exception isolation;
* idempotent unsubscribe;
* stable/provisional event declarations;
* normalized failure counters/status;
* credential sanitization;
* retry attempt metadata;
* mixed retry → non-retryable failure;
* queued/in-flight cancellation;
* retry cancellation and stale-generation protection.

### Installer

The installer regression matrix passed on:

* [x] Node 22
* [x] Node 24
* [x] Node 25

For each Node version:

* [x] Windows PowerShell 5.1 parse
* [x] Windows PowerShell 5.1 regression suite
* [x] PowerShell 7 parse
* [x] PowerShell 7 regression suite

The regression suite covers clean upstream rewrites, dirty/staged/untracked/local-commit preservation, local-ahead checkouts, default Keep behavior, explicit Discard, ignored-file preservation, decision-time races and content-aware destructive revalidation.

## Checklist

* [x] Commit messages follow conventional commit style.
* [x] No scheduler metadata or queue-position contract included.
* [x] Existing companion control API remains backward-compatible.
* [x] No request bodies or credential-bearing values are exposed through the event API.
* [x] Final history is limited to two commits, matching the two PR1 workstreams.
* [ ] `index.js` ESLint / syntax checks — not applicable; this PR does not change the userscript.
* [ ] Discord-console userscript verification — not applicable; this PR changes the Vencord plugin/installer paths.
* [ ] `CONFIG.VERSION` / README changelog — intentionally left to the release/version bump because `PLUGIN_VERSION` must remain in sync with `index.js`.
