### PR TITLE
feat: show the Orb payout beside each quest

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,6 +183,33 @@
         return Number.isNaN(e) || e > Date.now();
     };
 
+    // Orbs a quest pays out, as { orbs, premium }, or null when it pays none. Every reward entry
+    // is summed. The quantity sits on the entry and a quest can list several, so reading
+    // rewards[0] reports no Orbs at all for a quest that lists an in-game item first.
+    // premiumOrbQuantity is Discord's own Nitro figure and is sometimes absent or equal, so it
+    // falls back to the base number rather than being multiplied here.
+    const orbReward = config => {
+        const rewards = config?.rewardsConfig?.rewards;
+        if (!Array.isArray(rewards)) return null;
+        const amount = v => (typeof v === 'number' && Number.isFinite(v) && v > 0 ? v : 0);
+
+        let orbs = 0, premium = 0;
+        for (const r of rewards) {
+            const base = amount(r?.orbQuantity);
+            if (!base) continue;
+            orbs += base;
+            premium += amount(r?.premiumOrbQuantity) || base;
+        }
+        return orbs > 0 ? { orbs, premium } : null;
+    };
+
+    // The Nitro figure is only named when it differs, so a non-subscriber is not told the same
+    // number twice.
+    const fmtOrbs = reward => {
+        if (!reward) return '';
+        return reward.premium > reward.orbs ? `${reward.orbs} Orbs (${reward.premium} with Nitro)` : `${reward.orbs} Orbs`;
+    };
+
     // The server-sealed attribution blob Discord echoes back when enrolling in or claiming a
     // quest. The server issues it per quest and ships it with the quest list; the client
     // returns it unmodified. Orion sent neither sealed field, so every enrollment and claim it
@@ -501,6 +528,7 @@
                 .native-toggle:checked { background: var(--control-primary-background-default); }
                 .native-toggle:checked::after { transform: translateX(20px); }
 
+                .orb-total { display: none; padding-top: 12px; font-size: 11px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: #5865F2; text-align: center; flex-shrink: 0; }
                 .picker-actions { display: flex; gap: 10px; padding-top: 12px; flex-shrink: 0; }
                 .quest-pick-btn { flex: 1; padding: 10px; border: 1px solid; border-radius: var(--radius-sm, 8px); font-size: 13px; font-weight: 700; cursor: pointer; transition: 0.2s; display: flex; align-items: center; justify-content: center; gap: 6px; font-family: inherit; color: #fff;}
                 .quest-pick-btn.start { background-color: var(--control-connected-background-default); border-color: var(--control-connected-border-default); }
@@ -890,12 +918,17 @@
                     }
                     rewardTypes.get(rewardType).count++;
 
+                    const orbs = orbReward(q.config);
+
                     items.push({
                         id: q.id,
                         name: q.config?.messages?.questName ?? "Unknown Quest",
                         type: displayType,
                         rewardType,
                         rewardText,
+                        orbs: orbs?.orbs ?? 0,
+                        premiumOrbs: orbs?.premium ?? 0,
+                        orbText: fmtOrbs(orbs),
                         color: meta.color
                     });
                 });
@@ -903,13 +936,13 @@
                 if (!items.length) return closePicker({ selectedQuests: new Set(), autoEnroll: false, autoClaim: false, playSound: false });
 
                 const buildCard = (q) => `
-                    <label class="quest-pick" data-rt="${q.rewardType}" data-qt="${q.type}" style="border-left-color: ${q.color};">
+                    <label class="quest-pick" data-rt="${q.rewardType}" data-qt="${q.type}" data-orbs="${q.orbs}" data-premium-orbs="${q.premiumOrbs}" style="border-left-color: ${q.color};">
                         <input type="checkbox" name="quests" value="${q.id}" class="native-cb" checked>
                         <div class="task-info">
                             <div class="task-name" title="${esc(q.name)}">${esc(q.name)}</div>
                             <div class="task-meta" style="justify-content: flex-start; gap: 8px;">
                                 <span style="text-transform: uppercase; color: var(--text-subtle);">${esc(q.type)}</span>
-                                <span style="color: ${q.color};">${esc(q.rewardText)}</span>
+                                <span style="color: ${q.color};">${esc(q.orbText || q.rewardText)}</span>
                             </div>
                         </div>
                     </label>`;
@@ -950,6 +983,8 @@
                             </div>
                         </div>
 
+                        <div id="orion-orb-total" class="orb-total"></div>
+
                         <div class="picker-actions">
                             <button type="button" class="quest-pick-btn deselect" id="select-all-btn">DESELECT ALL</button>
                             <button type="submit" class="quest-pick-btn start" id="start-btn">${ICONS.BOLT} <span id="start-btn-text">START (${items.length})</span></button>
@@ -966,6 +1001,17 @@
                 const syncUI = () => {
                     const visibleCbs = getVisibleCheckboxes();
                     const totalChecked = visibleCbs.filter(cb => cb.checked).length;
+
+                    // Counts the selected quests only, so a reward filter or a deselect moves the
+                    // number. A list-wide total would stay put while the selection changed under it.
+                    const orbTotal = document.getElementById('orion-orb-total');
+                    if (orbTotal) {
+                        const picked = visibleCbs.filter(cb => cb.checked).map(cb => cb.closest('.quest-pick'));
+                        const sum = attr => picked.reduce((total, el) => total + (Number(el?.getAttribute(attr)) || 0), 0);
+                        const orbs = sum('data-orbs');
+                        orbTotal.textContent = orbs > 0 ? `${fmtOrbs({ orbs, premium: sum('data-premium-orbs') })} selected` : '';
+                        orbTotal.style.display = orbs > 0 ? 'block' : 'none';
+                    }
 
                     const startBtnText = document.getElementById('start-btn-text');
                     if (startBtnText) startBtnText.textContent = `START (${totalChecked})`;

--- a/index.tsx
+++ b/index.tsx
@@ -31,6 +31,7 @@ import {
     subscribeSchedulerState as subscribeOrionSchedulerState,
 } from "./orion";
 import { repairSuppressedPresence } from "./patcher";
+import { formatOrbReward, questOrbReward, totalOrbReward, type OrbReward } from "./questRewards";
 import { resolveQuestTarget } from "./questTarget";
 import type { SchedulerSnapshot } from "./schedulerMetadata";
 import { settings } from "./settings";
@@ -290,21 +291,45 @@ function statusSummary(): string {
     };
     const claimable = entries.filter(stillUnclaimed).length;
 
+    // A dashboard entry carries progress only, so the payout comes from the quest the store still
+    // holds. The task line and both totals below want the same number, so each quest is read once
+    // instead of three times.
+    const orbsById = new Map<string, OrbReward | null>();
+    for (const e of entries) {
+        let reward: OrbReward | null = null;
+        try {
+            reward = questOrbReward(store?.getQuest?.(e.id)?.config);
+        } catch {
+            reward = null;
+        }
+        orbsById.set(e.id, reward);
+    }
+
     const lines = entries.map(e => {
         const pct = e.max > 0 ? Math.min(100, (e.cur / e.max) * 100).toFixed(0) : "?";
+        const orbs = formatOrbReward(orbsById.get(e.id) ?? null);
+        const payout = orbs ? ` [${orbs}]` : "";
         const waiting = e.actionRequired === "ENROLL"
             ? ", waiting for you to accept it in Discord's Quests page"
             : "";
         const why = e.status === "FAILED" && e.reason ? `, ${e.reason}` : "";
         const reward = stillUnclaimed(e) ? ", reward not claimed yet" : "";
-        return `• ${e.name}: ${e.status} (${pct}%)${waiting}${why}${reward}`;
+        return `• ${e.name}: ${e.status} (${pct}%)${payout}${waiting}${why}${reward}`;
     });
+
+    const orbTotal = totalOrbReward([...orbsById.values()]);
+    const orbsWaiting = totalOrbReward(entries.filter(stillUnclaimed).map(e => orbsById.get(e.id) ?? null));
 
     const header = `Orion ${PLUGIN_VERSION} ${running ? "running" : "stopped"}, ${entries.length} task(s): ${breakdown}`;
     const footer = claimable > 0
         ? [`${claimable} reward(s) waiting. Claim them on Discord's Quests page, or turn on "Try to claim reward" to have Orion attempt it (claiming often triggers a captcha).`]
         : [];
-    return [header, ...lines, ...footer].join("\n");
+    // Orbs land on the account at claim time, so the total is what these tasks are worth and the
+    // second half is how much of it sits unclaimed.
+    const orbLine = orbTotal
+        ? [`Orbs: ${formatOrbReward(orbTotal)} across these task(s)${orbsWaiting ? `, ${formatOrbReward(orbsWaiting)} of it still to claim` : ""}.`]
+        : [];
+    return [header, ...lines, ...orbLine, ...footer].join("\n");
 }
 
 function formatCandidates(names: string[]): string {

--- a/questRewards.ts
+++ b/questRewards.ts
@@ -1,0 +1,71 @@
+/*
+ * OrionQuests, a Vencord userplugin
+ * Copyright (c) 2026 nyxxbit
+ * SPDX-License-Identifier: MIT
+ *
+ * Pure helpers for the Orb payout Discord attaches to a quest's rewardsConfig.
+ */
+
+export interface OrbReward {
+    /** orbQuantity, summed over every reward entry that carries one. */
+    orbs: number;
+    /** premiumOrbQuantity, the Nitro payout. Equals orbs when Discord sends no separate figure. */
+    premiumOrbs: number;
+}
+
+function finite(value: unknown): number {
+    return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * Orbs a quest pays out, or null when it pays none.
+ *
+ * Every reward entry is summed. Reward type 4 is what the picker colours a quest by, but the
+ * quantity lives on the entry and a quest may list several, so reading rewards[0] under-reports
+ * a quest that lists an in-game item before its Orbs.
+ *
+ * premiumOrbQuantity is Discord's own Nitro figure (1.2x per its Orbs FAQ) and is sometimes
+ * absent or equal to orbQuantity, so it falls back to the base number rather than being
+ * multiplied here.
+ */
+export function questOrbReward(config: any): OrbReward | null {
+    const rewards = config?.rewardsConfig?.rewards;
+    if (!Array.isArray(rewards)) return null;
+
+    let orbs = 0;
+    let premiumOrbs = 0;
+    for (const reward of rewards) {
+        const base = finite(reward?.orbQuantity);
+        if (!base) continue;
+        orbs += base;
+        premiumOrbs += finite(reward?.premiumOrbQuantity) || base;
+    }
+
+    return orbs > 0 ? { orbs, premiumOrbs } : null;
+}
+
+/** Sum of several quests' payouts, or null when none of them pay Orbs. */
+export function totalOrbReward(rewards: Array<OrbReward | null>): OrbReward | null {
+    let orbs = 0;
+    let premiumOrbs = 0;
+    for (const reward of rewards) {
+        if (!reward) continue;
+        orbs += reward.orbs;
+        premiumOrbs += reward.premiumOrbs;
+    }
+
+    return orbs > 0 ? { orbs, premiumOrbs } : null;
+}
+
+/**
+ * One payout as text, empty for a quest that pays no Orbs.
+ *
+ * The Nitro figure is named only when it differs from the base one, so a non-subscriber is not
+ * told the same number twice.
+ */
+export function formatOrbReward(reward: OrbReward | null): string {
+    if (!reward) return "";
+    return reward.premiumOrbs > reward.orbs
+        ? `${reward.orbs} Orbs (${reward.premiumOrbs} with Nitro)`
+        : `${reward.orbs} Orbs`;
+}

--- a/tests/questRewards.test.ts
+++ b/tests/questRewards.test.ts
@@ -1,0 +1,74 @@
+/*
+ * OrionQuests Orb reward parsing tests.
+ * Run from a Vencord checkout:
+ * pnpm exec tsx --test src/userplugins/discord-quest-completer/tests/questRewards.test.ts
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatOrbReward, questOrbReward, totalOrbReward } from "../questRewards";
+
+const orbQuest = (rewards: any[]) => ({ rewardsConfig: { rewards } });
+
+test("reads the Orb payout and the Nitro figure beside it", () => {
+    const config = orbQuest([{ type: 4, orbQuantity: 240, premiumOrbQuantity: 288 }]);
+
+    assert.deepEqual(questOrbReward(config), { orbs: 240, premiumOrbs: 288 });
+});
+
+test("falls back to the base payout when Discord sends no premium figure", () => {
+    assert.deepEqual(questOrbReward(orbQuest([{ type: 4, orbQuantity: 150 }])), { orbs: 150, premiumOrbs: 150 });
+    assert.deepEqual(
+        questOrbReward(orbQuest([{ type: 4, orbQuantity: 150, premiumOrbQuantity: null }])),
+        { orbs: 150, premiumOrbs: 150 }
+    );
+});
+
+test("sums every reward entry, not just the first one", () => {
+    const config = orbQuest([
+        { type: 1, messages: { name: "In-game item" } },
+        { type: 4, orbQuantity: 100, premiumOrbQuantity: 120 },
+        { type: 4, orbQuantity: 50 },
+    ]);
+
+    assert.deepEqual(questOrbReward(config), { orbs: 150, premiumOrbs: 170 });
+});
+
+test("a quest that pays no Orbs reports none", () => {
+    assert.equal(questOrbReward(orbQuest([{ type: 3, messages: { name: "Avatar decoration" } }])), null);
+    assert.equal(questOrbReward(orbQuest([])), null);
+    assert.equal(questOrbReward({}), null);
+    assert.equal(questOrbReward(undefined), null);
+});
+
+test("junk quantities are ignored rather than printed", () => {
+    const config = orbQuest([
+        { type: 4, orbQuantity: "240" },
+        { type: 4, orbQuantity: Number.NaN },
+        { type: 4, orbQuantity: -10 },
+    ]);
+
+    assert.equal(questOrbReward(config), null);
+});
+
+test("a negative premium figure does not drag the Nitro total below the base one", () => {
+    const config = orbQuest([{ type: 4, orbQuantity: 200, premiumOrbQuantity: -5 }]);
+
+    assert.deepEqual(questOrbReward(config), { orbs: 200, premiumOrbs: 200 });
+});
+
+test("totals skip quests without Orbs and report nothing when none pay any", () => {
+    assert.deepEqual(
+        totalOrbReward([{ orbs: 240, premiumOrbs: 288 }, null, { orbs: 60, premiumOrbs: 60 }]),
+        { orbs: 300, premiumOrbs: 348 }
+    );
+    assert.equal(totalOrbReward([null, null]), null);
+    assert.equal(totalOrbReward([]), null);
+});
+
+test("the Nitro figure is only named when it differs", () => {
+    assert.equal(formatOrbReward({ orbs: 240, premiumOrbs: 288 }), "240 Orbs (288 with Nitro)");
+    assert.equal(formatOrbReward({ orbs: 240, premiumOrbs: 240 }), "240 Orbs");
+    assert.equal(formatOrbReward(null), "");
+});

--- a/types.ts
+++ b/types.ts
@@ -15,7 +15,16 @@ export interface Quest {
         messages?: { questName?: string; };
         taskConfig?: TaskConfig;
         taskConfigV2?: TaskConfig;
-        rewardsConfig?: { rewards?: Array<{ type?: number; messages?: { name?: string; }; }>; };
+        rewardsConfig?: {
+            rewards?: Array<{
+                type?: number;
+                messages?: { name?: string; };
+                /** Orb payout. Discord sends orb_quantity; the store hands it over camel-cased. */
+                orbQuantity?: number | null;
+                /** The same payout for Nitro subscribers, absent on quests that pay the same. */
+                premiumOrbQuantity?: number | null;
+            }>;
+        };
     };
     userStatus?: {
         completedAt?: string;


### PR DESCRIPTION
## Summary

Show the Orb payout for each quest in the picker and in `/orion status`.

Closes #86.

## Why

Both surfaces already know a quest pays Orbs: the picker colours a card by reward type 4 and filters on it. Neither says how many, so deciding which quests are worth a slot means counting them on Discord's Quests page.

The number is in the payload the client already holds. Each entry of `config.rewardsConfig.rewards` carries `orbQuantity`, with `premiumOrbQuantity` beside it for the Nitro figure, so nothing new is fetched and no extra request is made.

## Changes

* add `questRewards.ts` with the payout parsing and formatting, plus tests
* picker cards show the payout, and the total under the list follows the reward filters and the checkboxes
* `/orion status` appends the payout per task and adds one line for the run
* type `orbQuantity` and `premiumOrbQuantity` on the quest reward shape in `types.ts`

The payout is summed over every reward entry rather than read off `rewards[0]`, which is only where the picker takes its colour from. A quest that lists an in-game item before its Orbs would otherwise report none. No such quest has been seen: nyxxbit checked 66 live quests and every Orb payout sat alone at `rewards[0]`. The summing covers what the payload shape allows, and nothing observed needed it.

The Nitro figure comes from `premiumOrbQuantity` rather than multiplying by 1.2 here, and falls back to the base number when Discord sends no separate one. It is only printed when the two differ.

The run line is split into what the tasks are worth and how much of that is still unclaimed, since Orbs only land on the account at claim time.

## Testing

`node --check index.js` and `npx eslint@9 index.js` pass. The new `tests/questRewards.test.ts` covers summed entries, a missing or equal premium figure, junk quantities, and quests that pay no Orbs.

Checked by hand on Stable host 1.0.9257 (build 611316) with Vencord 0850f37f, both surfaces, on the same three Orb quests (700, 200, 200).

In the picker the total reads 1100 Orbs (1320 with Nitro), follows DESELECT ALL and the reward filters, and disappears at zero selected. `/orion status` partway through the run, with two quests finished and unclaimed:

```
Orion v4.11.0 running, 3 task(s): 2 completed, 1 running
• Marvel Rivals S10: verify school email, get 10 free trial costumes: RUNNING (40%) [700 Orbs (840 with Nitro)]
• Marvel Rivals S10: verify school email, get 10 free trial costumes: COMPLETED (100%) [200 Orbs (240 with Nitro)], reward not claimed yet
• Fatal Fury Switch 2: COMPLETED (100%) [200 Orbs (240 with Nitro)], reward not claimed yet
Orbs: 1100 Orbs (1320 with Nitro) across these task(s), 400 Orbs (480 with Nitro) of it still to claim.
2 reward(s) waiting. Claim them on Discord's Quests page, or turn on "Try to claim reward" to have Orion attempt it (claiming often triggers a captcha).
```

Earlier in the same run, with nothing claimable yet, the line ended after the first half.
