### PR TITLE
feat: show the account's Orb balance beside the payout line

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,6 +210,20 @@
         return reward.premium > reward.orbs ? `${reward.orbs} Orbs (${reward.premium} with Nitro)` : `${reward.orbs} Orbs`;
     };
 
+    // The Orb balance Discord reports for the account, or null for anything that is not a whole
+    // non-negative number. Zero is a real balance and is kept, unlike a payout of zero.
+    const orbBalance = v => (typeof v === 'number' && Number.isInteger(v) && v >= 0 ? v : null);
+
+    // Orbs on the account. VirtualCurrencyStore holds the figure Discord's own Orb pill shows
+    // once the client has fetched it, so that is read first. Before then it is null and one GET
+    // of the balance endpoint fills it in. Nothing polls; this runs once when the picker opens.
+    const readOrbBalance = async () => {
+        const stored = orbBalance(Mods.OrbStore?.balance);
+        if (stored !== null) return stored;
+        const res = await Mods.API.get({ url: '/users/@me/virtual-currency/balance' });
+        return orbBalance(res?.body?.balance);
+    };
+
     // The server-sealed attribution blob Discord echoes back when enrolling in or claiming a
     // quest. The server issues it per quest and ships it with the quest list; the client
     // returns it unmodified. Orion sent neither sealed field, so every enrollment and claim it
@@ -998,6 +1012,9 @@
                 const getVisibleCheckboxes = () => Array.from(form.querySelectorAll('.quest-pick input[type="checkbox"]'))
                     .filter(cb => !cb.closest('.quest-pick').classList.contains('hidden'));
 
+                // Filled in once the balance read below settles; empty until then and on failure.
+                let balanceText = '';
+
                 const syncUI = () => {
                     const visibleCbs = getVisibleCheckboxes();
                     const totalChecked = visibleCbs.filter(cb => cb.checked).length;
@@ -1009,8 +1026,10 @@
                         const picked = visibleCbs.filter(cb => cb.checked).map(cb => cb.closest('.quest-pick'));
                         const sum = attr => picked.reduce((total, el) => total + (Number(el?.getAttribute(attr)) || 0), 0);
                         const orbs = sum('data-orbs');
-                        orbTotal.textContent = orbs > 0 ? `${fmtOrbs({ orbs, premium: sum('data-premium-orbs') })} selected` : '';
-                        orbTotal.style.display = orbs > 0 ? 'block' : 'none';
+                        const selectedText = orbs > 0 ? `${fmtOrbs({ orbs, premium: sum('data-premium-orbs') })} selected` : '';
+                        const text = [selectedText, balanceText].filter(Boolean).join(' · ');
+                        orbTotal.textContent = text;
+                        orbTotal.style.display = text ? 'block' : 'none';
                     }
 
                     const startBtnText = document.getElementById('start-btn-text');
@@ -1093,6 +1112,17 @@
                 // apply layout lock and sync initial button states
                 body.classList.add('picker-mode');
                 syncUI();
+
+                readOrbBalance()
+                    .then(balance => {
+                        if (balance === null) {
+                            Logger.log('[System] Discord sent no Orb balance, so the picker shows none.', 'warn');
+                            return;
+                        }
+                        balanceText = `${balance} Orbs on the account`;
+                        syncUI();
+                    })
+                    .catch(e => Logger.log(`[System] Could not read the Orb balance: ${e?.message ?? e}`, 'warn'));
             });
         }
     };
@@ -2325,6 +2355,7 @@
                     ChanStore: W.findStore('ChannelStore'),
                     GuildChanStore: W.findStore('GuildChannelStore'),
                     UserStore: W.findStore('UserStore'),
+                    OrbStore: W.findStore('VirtualCurrencyStore'),
                     Dispatcher: W.Common?.FluxDispatcher || W.findByProps('dispatch', 'subscribe', 'flushWaitQueue'),
                     API: W.Common?.RestAPI || W.findByProps('get', 'post', 'del'),
                     Router: routerModule,
@@ -2450,6 +2481,7 @@
                 ChanStore: findStore('ChannelStore'),
                 GuildChanStore: findStore('GuildChannelStore'),
                 UserStore: findStore('UserStore'),
+                OrbStore: findStore('VirtualCurrencyStore'),
                 Dispatcher: findDispatcher(),
                 API: findAPI(),
                 Router: findRouter(),

--- a/index.js
+++ b/index.js
@@ -215,12 +215,20 @@
     const orbBalance = v => (typeof v === 'number' && Number.isInteger(v) && v >= 0 ? v : null);
 
     // Orbs on the account. VirtualCurrencyStore holds the figure Discord's own Orb pill shows
-    // once the client has fetched it, so that is read first. Before then it is null and one GET
-    // of the balance endpoint fills it in. Nothing polls; this runs once when the picker opens.
+    // once the client has fetched it, so that is read first. Discord keeps it current itself:
+    // the gateway pushes VIRTUAL_CURRENCY_BALANCE_UPDATE into it and LOGIN_SUCCESS clears it,
+    // so a number there belongs to the signed-in account. Before then it is null and one GET of
+    // the balance endpoint fills it in. Nothing polls; this runs once when the picker opens.
+    // The GET has no such guarantee, so the account is checked on both sides of the await and
+    // a switch in between discards the response.
     const readOrbBalance = async () => {
-        const stored = orbBalance(Mods.OrbStore?.balance);
+        const store = Mods.OrbStore;
+        const stored = orbBalance(store?.getCurrentBalance?.() ?? store?.balance);
         if (stored !== null) return stored;
+        const account = Mods.UserStore?.getCurrentUser?.()?.id ?? null;
         const res = await Mods.API.get({ url: '/users/@me/virtual-currency/balance' });
+        const after = Mods.UserStore?.getCurrentUser?.()?.id ?? null;
+        if (after !== account) throw new Error('the account changed during the read');
         return orbBalance(res?.body?.balance);
     };
 

--- a/index.js
+++ b/index.js
@@ -220,12 +220,14 @@
     // so a number there belongs to the signed-in account. Before then it is null and one GET of
     // the balance endpoint fills it in. Nothing polls; this runs once when the picker opens.
     // The GET has no such guarantee, so the account is checked on both sides of the await and
-    // a switch in between discards the response.
+    // a switch in between discards the response. With no signed-in account there is nothing to
+    // check against, so the read stops before the request.
     const readOrbBalance = async () => {
         const store = Mods.OrbStore;
         const stored = orbBalance(store?.getCurrentBalance?.() ?? store?.balance);
         if (stored !== null) return stored;
         const account = Mods.UserStore?.getCurrentUser?.()?.id ?? null;
+        if (!account) throw new Error('no account is signed in');
         const res = await Mods.API.get({ url: '/users/@me/virtual-currency/balance' });
         const after = Mods.UserStore?.getCurrentUser?.()?.id ?? null;
         if (after !== account) throw new Error('the account changed during the read');

--- a/index.tsx
+++ b/index.tsx
@@ -21,6 +21,7 @@ import {
     pauseAllQuests,
     pauseQuest,
     readDashboard,
+    readOrbBalance,
     readSchedulerSnapshot,
     resetForAccountChange,
     resumeAllQuests,
@@ -31,7 +32,7 @@ import {
     subscribeSchedulerState as subscribeOrionSchedulerState,
 } from "./orion";
 import { repairSuppressedPresence } from "./patcher";
-import { formatOrbReward, questOrbReward, totalOrbReward, type OrbReward } from "./questRewards";
+import { formatOrbBalance, formatOrbReward, questOrbReward, totalOrbReward, type OrbReward } from "./questRewards";
 import { resolveQuestTarget } from "./questTarget";
 import type { SchedulerSnapshot } from "./schedulerMetadata";
 import { settings } from "./settings";
@@ -261,7 +262,7 @@ async function ensureReadyStop(): Promise<string> {
     return ensureStop();
 }
 
-function statusSummary(): string {
+async function statusSummary(): Promise<string> {
     const running = isEngineRunning();
     const entries = readDashboard();
     if (!running && entries.length === 0) {
@@ -329,7 +330,16 @@ function statusSummary(): string {
     const orbLine = orbTotal
         ? [`Orbs: ${formatOrbReward(orbTotal)} across these task(s)${orbsWaiting ? `, ${formatOrbReward(orbsWaiting)} of it still to claim` : ""}.`]
         : [];
-    return [header, ...lines, ...orbLine, ...footer].join("\n");
+    // The balance may need a request, unlike everything else here, so a failed read prints its
+    // reason on that one line and leaves the rest of the status intact.
+    let balanceLine: string;
+    try {
+        const balance = formatOrbBalance(await readOrbBalance());
+        balanceLine = balance ? `Balance: ${balance} on the account.` : "Balance: unavailable, Discord sent no number.";
+    } catch (error) {
+        balanceLine = `Balance: unavailable, ${error instanceof Error ? error.message : String(error)}.`;
+    }
+    return [header, ...lines, ...orbLine, balanceLine, ...footer].join("\n");
 }
 
 function formatCandidates(names: string[]): string {
@@ -555,7 +565,7 @@ export default definePlugin({
                     else if (action === "stop") response = await ensureReadyStop();
                     else if (action === "pause") response = await ensureReadyPause(target);
                     else if (action === "resume") response = await ensureReadyResume(target);
-                    else response = statusSummary();
+                    else response = await statusSummary();
                 } catch (error) {
                     response = `Control unavailable: ${error instanceof Error ? error.message : String(error)}`;
                 }

--- a/index.tsx
+++ b/index.tsx
@@ -265,13 +265,16 @@ async function ensureReadyStop(): Promise<string> {
 async function statusSummary(): Promise<string> {
     const running = isEngineRunning();
     const entries = readDashboard();
+    // A status with no tasks can still report the balance, and asking while nothing runs is the
+    // plain way to check it, so the early returns carry the line too.
     if (!running && entries.length === 0) {
         const outcome = getLastRunOutcome();
-        return outcome
+        const idle = outcome
             ? `Orion ${PLUGIN_VERSION} idle: ${outcome}\nUse \`/orion start\` to try again.`
             : `Orion ${PLUGIN_VERSION} idle. Use \`/orion start\` to begin.`;
+        return `${idle}\n${await balanceLine()}`;
     }
-    if (entries.length === 0) return running ? "Running. No active tasks yet." : "Idle.";
+    if (entries.length === 0) return `${running ? "Running. No active tasks yet." : "Idle."}\n${await balanceLine()}`;
 
     const tally = new Map<string, number>();
     for (const e of entries) tally.set(e.status, (tally.get(e.status) ?? 0) + 1);
@@ -330,16 +333,18 @@ async function statusSummary(): Promise<string> {
     const orbLine = orbTotal
         ? [`Orbs: ${formatOrbReward(orbTotal)} across these task(s)${orbsWaiting ? `, ${formatOrbReward(orbsWaiting)} of it still to claim` : ""}.`]
         : [];
-    // The balance may need a request, unlike everything else here, so a failed read prints its
-    // reason on that one line and leaves the rest of the status intact.
-    let balanceLine: string;
+    return [header, ...lines, ...orbLine, await balanceLine(), ...footer].join("\n");
+}
+
+// The balance may need a request, unlike everything else in a status, so a failed read prints
+// its reason on this one line and leaves the rest intact.
+async function balanceLine(): Promise<string> {
     try {
         const balance = formatOrbBalance(await readOrbBalance());
-        balanceLine = balance ? `Balance: ${balance} on the account.` : "Balance: unavailable, Discord sent no number.";
+        return balance ? `Balance: ${balance} on the account.` : "Balance: unavailable, Discord sent no number.";
     } catch (error) {
-        balanceLine = `Balance: unavailable, ${error instanceof Error ? error.message : String(error)}.`;
+        return `Balance: unavailable, ${error instanceof Error ? error.message : String(error)}.`;
     }
-    return [header, ...lines, ...orbLine, balanceLine, ...footer].join("\n");
 }
 
 function formatCandidates(names: string[]): string {

--- a/orion.ts
+++ b/orion.ts
@@ -213,16 +213,24 @@ export function getVirtualCurrencyStore(): any {
 
 /**
  * Orbs on the account. VirtualCurrencyStore holds the figure Discord's own Orb pill shows once
- * the client has fetched it, so that is read first. Before then it is null and one GET of the
- * balance endpoint fills it in. Nothing polls; this runs only when a status is asked for.
+ * the client has fetched it, so that is read first. Discord keeps it current itself: the gateway
+ * pushes VIRTUAL_CURRENCY_BALANCE_UPDATE into it and LOGIN_SUCCESS clears it, so a number there
+ * belongs to the signed-in account. Before then it is null and one GET of the balance endpoint
+ * fills it in. Nothing polls; this runs only when a status is asked for.
+ *
+ * The GET has no such guarantee, so the account is checked on both sides of the await and a
+ * switch in between discards the response.
  */
 export async function readOrbBalance(): Promise<number | null> {
-    const stored = orbBalance(getVirtualCurrencyStore()?.balance);
+    const store = getVirtualCurrencyStore();
+    const stored = orbBalance(store?.getCurrentBalance?.() ?? store?.balance);
     if (stored !== null) return stored;
 
     const API = (RestAPI as any) || findByProps("get", "post", "del");
     if (!API) throw new Error("RestAPI not found");
+    const account = getCurrentUserId();
     const res = await API.get({ url: "/users/@me/virtual-currency/balance" });
+    if (getCurrentUserId() !== account) throw new Error("the account changed during the read");
     return orbBalance(res?.body?.balance);
 }
 

--- a/orion.ts
+++ b/orion.ts
@@ -219,7 +219,8 @@ export function getVirtualCurrencyStore(): any {
  * fills it in. Nothing polls; this runs only when a status is asked for.
  *
  * The GET has no such guarantee, so the account is checked on both sides of the await and a
- * switch in between discards the response.
+ * switch in between discards the response. With no signed-in account there is nothing to check
+ * against, so the read stops before the request.
  */
 export async function readOrbBalance(): Promise<number | null> {
     const store = getVirtualCurrencyStore();
@@ -229,6 +230,7 @@ export async function readOrbBalance(): Promise<number | null> {
     const API = (RestAPI as any) || findByProps("get", "post", "del");
     if (!API) throw new Error("RestAPI not found");
     const account = getCurrentUserId();
+    if (!account) throw new Error("no account is signed in");
     const res = await API.get({ url: "/users/@me/virtual-currency/balance" });
     if (getCurrentUserId() !== account) throw new Error("the account changed during the read");
     return orbBalance(res?.body?.balance);

--- a/orion.ts
+++ b/orion.ts
@@ -18,6 +18,7 @@ import { companionFailure, COMPANION_EVENT_CODES, emitCompanionEvent } from "./c
 import { setAchievementBypassHook } from "./hooks";
 import { Patcher } from "./patcher";
 import { questBlocker, recordOutcome, selectQuestTaskConfig, summarizeRun, taskEntries } from "./questConfig";
+import { orbBalance } from "./questRewards";
 import { schedulerLaneForTaskType, schedulerMetadata, type SchedulerLane, type SchedulerSnapshot, type SchedulerTaskView } from "./schedulerMetadata";
 import { settings } from "./settings";
 import { TaskControlRegistry, type TaskLifecycle } from "./taskControl";
@@ -100,6 +101,7 @@ let traffic: Traffic | null = null;
 let tasks: TaskRunner | null = null;
 let questStore: any = null;
 let userStore: any = null;
+let virtualCurrencyStore: any = null;
 let sessionOwnerUserId: string | null = null;
 /**
  * Why the last run ended, when it ended on its own rather than by the user stopping it.
@@ -202,6 +204,26 @@ export function getQuestStore(): any {
 export function getUserStore(): any {
     if (!userStore) userStore = findStore("UserStore");
     return userStore;
+}
+
+export function getVirtualCurrencyStore(): any {
+    if (!virtualCurrencyStore) virtualCurrencyStore = findStore("VirtualCurrencyStore");
+    return virtualCurrencyStore;
+}
+
+/**
+ * Orbs on the account. VirtualCurrencyStore holds the figure Discord's own Orb pill shows once
+ * the client has fetched it, so that is read first. Before then it is null and one GET of the
+ * balance endpoint fills it in. Nothing polls; this runs only when a status is asked for.
+ */
+export async function readOrbBalance(): Promise<number | null> {
+    const stored = orbBalance(getVirtualCurrencyStore()?.balance);
+    if (stored !== null) return stored;
+
+    const API = (RestAPI as any) || findByProps("get", "post", "del");
+    if (!API) throw new Error("RestAPI not found");
+    const res = await API.get({ url: "/users/@me/virtual-currency/balance" });
+    return orbBalance(res?.body?.balance);
 }
 
 export function getCurrentUserId(): string | null {

--- a/questRewards.ts
+++ b/questRewards.ts
@@ -69,3 +69,16 @@ export function formatOrbReward(reward: OrbReward | null): string {
         ? `${reward.orbs} Orbs (${reward.premiumOrbs} with Nitro)`
         : `${reward.orbs} Orbs`;
 }
+
+/**
+ * The Orb balance Discord reports for the account, or null for anything that is not a whole
+ * non-negative number. Zero is a real balance and is kept, unlike a payout of zero.
+ */
+export function orbBalance(value: unknown): number | null {
+    return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+/** The balance as text, empty when it is unknown. */
+export function formatOrbBalance(balance: number | null): string {
+    return balance === null ? "" : `${balance} Orbs`;
+}

--- a/tests/questRewards.test.ts
+++ b/tests/questRewards.test.ts
@@ -7,7 +7,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { formatOrbReward, questOrbReward, totalOrbReward } from "../questRewards";
+import { formatOrbBalance, formatOrbReward, orbBalance, questOrbReward, totalOrbReward } from "../questRewards";
 
 const orbQuest = (rewards: any[]) => ({ rewardsConfig: { rewards } });
 
@@ -71,4 +71,20 @@ test("the Nitro figure is only named when it differs", () => {
     assert.equal(formatOrbReward({ orbs: 240, premiumOrbs: 288 }), "240 Orbs (288 with Nitro)");
     assert.equal(formatOrbReward({ orbs: 240, premiumOrbs: 240 }), "240 Orbs");
     assert.equal(formatOrbReward(null), "");
+});
+
+test("an account balance is any whole non-negative number, zero included", () => {
+    assert.equal(orbBalance(3240), 3240);
+    assert.equal(orbBalance(0), 0);
+    assert.equal(orbBalance(-1), null);
+    assert.equal(orbBalance(12.5), null);
+    assert.equal(orbBalance("3240"), null);
+    assert.equal(orbBalance(null), null);
+    assert.equal(orbBalance(undefined), null);
+});
+
+test("a balance prints as Orbs and an unknown one prints nothing", () => {
+    assert.equal(formatOrbBalance(3240), "3240 Orbs");
+    assert.equal(formatOrbBalance(0), "0 Orbs");
+    assert.equal(formatOrbBalance(null), "");
 });


### PR DESCRIPTION
## Summary

Show the account's Orb balance beside the payout line, in `/orion status` and in the picker.

The read-only half of #87, which you said you would take a PR for. Nothing here spends or redeems.

## Why

The payout line from #88 says what a run is worth but not what the account already holds, which is what decides whether a shop item is within reach.

## Changes

* `orion.ts` gets `readOrbBalance()`. `VirtualCurrencyStore` carries the figure Discord's own Orb pill shows once the client has fetched it, so that is read first and costs no request. Before then it is `null` and one `GET /users/@me/virtual-currency/balance` fills it in. It runs only when `/orion status` is asked for or the picker opens; nothing polls.
* `/orion status` adds `Balance: N Orbs on the account.` after the `Orbs:` line. A failed read prints its reason on that line and leaves the rest of the status intact.
* The picker appends `N Orbs on the account` to the selected-Orbs line under the list, and shows it alone when nothing is selected.
* `questRewards.ts` gets `orbBalance()` and `formatOrbBalance()` with tests. Zero is kept as a real balance, unlike a payout of zero.

## Testing

`node --check index.js`, `npx eslint@9 index.js`, and in a Vencord checkout the plugin tests (114 pass), `pnpm testTsc`, `pnpm lint`, `pnpm run build`.

Checked by hand on Stable with Vencord, both surfaces, against the Orb pill in Discord's shop. Status on 18 tasks ended with:

```
Orbs: 6700 Orbs (8040 with Nitro) across these task(s).
Balance: 2700 Orbs on the account.
```

The picker read `6700 ORBS (8040 WITH NITRO) SELECTED · 2700 ORBS ON THE ACCOUNT`, and `2700 ORBS ON THE ACCOUNT` alone after DESELECT ALL. Checked in the console afterwards: `VirtualCurrencyStore.balance` was still `null` and the GET returned `2700`, so both runs went through the fallback. The store only fills once Discord fetches it itself, which on this client had not happened without opening the shop, so the GET is the usual path and the store read is the saving when it does hold a number.
